### PR TITLE
landscape: fix normalizeUrbitColor

### DIFF
--- a/ui/src/state/util.ts
+++ b/ui/src/state/util.ts
@@ -54,7 +54,7 @@ export function normalizeUrbitColor(color: string): string {
   }
 
   const colorString = color.slice(2).replace('.', '').toUpperCase();
-  const lengthAdjustedColor = _.padEnd(colorString, 6, _.last(colorString));
+  const lengthAdjustedColor = _.padStart(colorString, 6, '0');
   return `#${lengthAdjustedColor}`;
 }
 


### PR DESCRIPTION
Brings the profile color into parity with Groups and Talk, fixes #96.

Groups:
![image](https://user-images.githubusercontent.com/748181/221445964-3721cdd7-8724-46c0-ad32-e261fa7bde45.png)

Landscape:
![image](https://user-images.githubusercontent.com/748181/221445979-a43f817e-2ced-4684-bb10-dd1e85d36f28.png)
