### PR TITLE
docket: handle filename with spaces

### DIFF
--- a/desk/app/docket.hoon
+++ b/desk/app/docket.hoon
@@ -673,9 +673,13 @@
   ::
   ++  fip
     =,  de-purl:html
-    %+  cook
+    ;:  cook
       |=(pork (weld q (drop p)))
-    (cook deft (more fas smeg))
+      deft
+      |=(a=cord (rash a (more fas smeg))) 
+      crip 
+      (star ;~(pose (cold '%20' (just ' ')) next))
+    ==
   ::
   ++  inline-js-response
     |=  js=cord


### PR DESCRIPTION
Resolves https://github.com/urbit/urbit/issues/5998

`++fip` crashes because `smeg` expects empty spaces to have been encoded as `%20`

Solution: parse all empty spaces to `%20` before it tries to parse the file name

