### PR TITLE
hood: keeping compat with both 415 and 414

### DIFF
--- a/desk/app/docket.hoon
+++ b/desk/app/docket.hoon
@@ -1,5 +1,5 @@
 /-  *docket, hood, treaty
-/+  *server, agentio, default-agent, multipart, dbug, verb
+/+  *server, *hood, agentio, default-agent, multipart, dbug, verb
 |%
 +$  card  card:agent:gall
 +$  app-state
@@ -229,7 +229,7 @@
     ?~  got=(~(get by tyr) desk)
       ~
     ?:  ?&  ?=(%dead zest.u.got)
-            ?=(~ (get-apps-have:hood our.bowl desk now.bowl))
+            ?=(~ (get-apps-have our.bowl desk now.bowl))
         ==
       ~
     `u=[desk (get-light-charge charge)]

--- a/desk/lib/hood.hoon
+++ b/desk/lib/hood.hoon
@@ -1,0 +1,8 @@
+=*  dude  dude:gall
+|%
+++  get-apps-have
+  |=  [our=ship =desk now=@da]
+  ^-  (list [=dude live=?])
+  %~  tap  in
+  .^((set [=dude live=?]) ge+/(scot %p our)/[desk]/(scot %da now))
+--

--- a/desk/sur/hood.hoon
+++ b/desk/sur/hood.hoon
@@ -1,0 +1,20 @@
+:: only the types from base-dev/sur/hood.hoon
+=,  clay
+=*  dude  dude:gall
+|%
++$  pike
+  $:  sync=(unit [=ship =desk])
+      hash=@uv
+      =zest
+      wic=(set weft)
+  ==
+::
++$  pikes  (map desk pike)
+::
+::  $rung: reference to upstream commit
+::
++$  rung  [=aeon =weft]
+::
++$  sync-state  [nun=@ta kid=(unit desk) let=@ud]
++$  sink        (unit [her=@p sud=desk kid=(unit desk) let=@ud])
+--


### PR DESCRIPTION
Instead of relying on the hood file from base-dev which introduced some incompatibilities, this retains the types from that file and pulls the one library function we depend on into it's own file which allows us to stay compatible with both 415 and 414.