### PR TITLE
wayfinding: placement

### DIFF
--- a/ui/src/components/LandscapeWayfinding.tsx
+++ b/ui/src/components/LandscapeWayfinding.tsx
@@ -128,7 +128,7 @@ export default function LandscapeWayfinding() {
 
   return (
     <Dropdown.Root>
-      <div className="fixed left-4 bottom-16 z-[100] sm:bottom-4">
+      <div className="fixed bottom-[4.25rem] left-4 z-[100] sm:bottom-4">
         <Dropdown.Trigger className="relative" asChild>
           <button className="h-9 w-9 cursor-pointer rounded-lg bg-black text-xl text-white">
             ?

--- a/ui/src/components/LandscapeWayfinding.tsx
+++ b/ui/src/components/LandscapeWayfinding.tsx
@@ -128,7 +128,7 @@ export default function LandscapeWayfinding() {
 
   return (
     <Dropdown.Root>
-      <div className="absolute left-4 bottom-16 z-50">
+      <div className="fixed left-4 bottom-16 z-[100] sm:bottom-4">
         <Dropdown.Trigger className="relative" asChild>
           <button className="h-9 w-9 cursor-pointer rounded-lg bg-black text-xl text-white">
             ?

--- a/ui/src/nav/Nav.tsx
+++ b/ui/src/nav/Nav.tsx
@@ -119,7 +119,7 @@ export const GetAppsLink = () => {
   return (
     <Link
       to="/get-apps"
-      className="flex h-9 w-full items-center space-x-2 rounded-lg bg-blue-soft px-3 py-2.5 sm:w-[150px] sm:justify-center"
+      className="flex h-9 w-[150px] items-center justify-center space-x-2 rounded-lg bg-blue-soft px-3 py-2.5"
     >
       <MagnifyingGlass16Icon className="h-4 w-4 fill-current text-blue" />
       <span className="whitespace-nowrap font-semibold text-blue">
@@ -183,7 +183,7 @@ export const Nav: FunctionComponent<NavProps> = ({ menu }) => {
       {/* Using portal so that we can retain the same nav items both in the dialog and in the base header */}
       <Portal.Root
         containerRef={dialogContentOpen ? dialogNavRef : navRef}
-        className="flex w-full items-center justify-center space-x-2"
+        className="flex w-full items-center space-x-2 sm:justify-center"
       >
         <SystemPrefsLink menuState={menuState} systemBlocked={systemBlocked} />
         <NotificationsLink

--- a/ui/src/nav/Nav.tsx
+++ b/ui/src/nav/Nav.tsx
@@ -119,7 +119,7 @@ export const GetAppsLink = () => {
   return (
     <Link
       to="/get-apps"
-      className="flex h-9 w-[150px] items-center justify-center space-x-2 rounded-lg bg-blue-soft px-3 py-2.5"
+      className="flex h-9 w-full items-center space-x-2 rounded-lg bg-blue-soft px-3 py-2.5 sm:w-[150px] sm:justify-center"
     >
       <MagnifyingGlass16Icon className="h-4 w-4 fill-current text-blue" />
       <span className="whitespace-nowrap font-semibold text-blue">

--- a/ui/src/pages/Grid.tsx
+++ b/ui/src/pages/Grid.tsx
@@ -44,7 +44,6 @@ export const Grid: FunctionComponent = () => {
 
   return (
     <div className="flex h-screen w-full flex-col">
-      {!disableWayfinding && <LandscapeWayfinding />}
       <header className="fixed bottom-0 left-0 z-30 flex w-full justify-center px-4 sm:sticky sm:bottom-auto sm:top-0">
         <Nav menu={menu} />
       </header>
@@ -63,6 +62,7 @@ export const Grid: FunctionComponent = () => {
           </Route>
         </ErrorBoundary>
       </main>
+      {!disableWayfinding && <LandscapeWayfinding />}
     </div>
   );
 };


### PR DESCRIPTION
This makes a small adjustment to the wayfinding button so it aligns a little better. Notably this makes the get urbit apps button look more like a search bar on mobile, but that makes the wayfinding button feel like it's not floating arbitrarily up.

**before**
![Screen Shot 2023-03-22 at 1 41 25 PM](https://user-images.githubusercontent.com/5466421/227005605-e0d04610-007c-427d-b4b0-b130604ab86a.png)

![Screen Shot 2023-03-22 at 1 41 32 PM](https://user-images.githubusercontent.com/5466421/227005627-d8a5930b-f02b-4e7e-ba6f-3c16e0f3bdce.png)


**after**
![Screen Shot 2023-03-22 at 1 31 34 PM](https://user-images.githubusercontent.com/5466421/227005091-38cd5338-105b-4623-8d07-5a795c22e10a.png)

![Screen Shot 2023-03-22 at 1 38 28 PM](https://user-images.githubusercontent.com/5466421/227005384-5a9dba22-e6e5-49f9-b243-035dd06e2b70.png)

