### PR TITLE
apps: update Goals path in suggestions

### DIFF
--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -124,7 +124,7 @@ export const APPS = [
     title: 'Goals',
     description: 'Urbit task manager.',
     color: '#EEDFC9',
-    link: '/apps/goals',
+    link: '/apps/gol-cli',
     section: SECTIONS.USEFUL,
     desk: 'gol-cli',
     source: '~dister-dozzod-niblyx-malnus',


### PR DESCRIPTION
This addresses feedback from the Goals team (~niblyx-malnus and ~sidlup-havwen):

> very nice surprise to see Goals listed in the new app installation feature of landscape! thanks! :)
> **sidlup-havwen** did notice that it does seem to redirect to `/app/goals` , though, when it should (for historical reasons) actually redirect to [...] `/apps/gol-cli`