### PR TITLE
notifications: fix duplicate notification issue

### DIFF
--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -9,10 +9,13 @@ export const makeBrowserNotification = (bin: Bin) => {
   const ship = bin.topYarn?.con.find(isYarnShip)?.ship || '';
   const emph = bin.topYarn?.con.find(isYarnEmph)?.emph || '';
   const emphLast = findLast(bin.topYarn?.con, isYarnEmph)?.emph || '';
+  const content = isYarnEmph(bin.topYarn?.con[2])
+    ? ''
+    : bin.topYarn.con[2] || '';
 
   try {
     new Notification(`Landscape: ${app}`, {
-      body: `${ship}${emph}${bin.topYarn.con[1]}${emphLast}`,
+      body: `${ship ? ship : emph}${bin.topYarn.con[1]}${emphLast} ${content}`,
     });
   } catch (error) {
     console.error(error);
@@ -21,10 +24,5 @@ export const makeBrowserNotification = (bin: Bin) => {
 
 export function isNewNotificationSupported() {
   if (!window.Notification || !Notification.requestPermission) return false;
-  try {
-    new Notification('');
-  } catch (e: any) {
-    if (e.name == 'TypeError') return false;
-  }
   return true;
 }


### PR DESCRIPTION
fixes #125 

I wasn't able to reproduce the exact issue in #125, but I think this was actually what the user was seeing.

We were firing off a test notification each time the count or unreadNotifications changed, along with the real notification itself.

We also weren't properly including notification content (DMs or mentions would just show that you got a DM or a mention, but not the content of the message). This fixes that.