### PR TITLE
ui: increase spacing at bottom of grid

### DIFF
--- a/ui/src/tiles/TileGrid.tsx
+++ b/ui/src/tiles/TileGrid.tsx
@@ -86,7 +86,7 @@ export const TileGrid = ({ menu }: TileGridProps) => {
       <div
         // This version of tailwind does not have h-fit
         style={{ height: 'fit-content' }}
-        className="grid w-full max-w-6xl grid-cols-2 justify-center gap-4 px-4 sm:grid-cols-[repeat(auto-fit,minmax(auto,250px))] md:px-8"
+        className="grid w-full max-w-6xl grid-cols-2 justify-center gap-4 pb-4 px-4 sm:grid-cols-[repeat(auto-fit,minmax(auto,250px))] md:pb-10 md:px-8"
       >
         {order
           .filter((d) => d !== window.desk && d in charges)


### PR DESCRIPTION
# Changes

This introduces some padding to the bottom of the grid. Before this change, the bottom of the grid was aligned to the bottom of the scrollable view

# Preview

Scrolled to the bottom:

## Before

<img width="1123" alt="image" src="https://user-images.githubusercontent.com/16504501/234119957-a92fe268-0378-4a52-ae4c-533306fdd08c.png">

## After

<img width="1119" alt="image" src="https://user-images.githubusercontent.com/16504501/234120041-aea67f57-47c7-47c5-9c36-ab86cd43ec50.png">
