### PR TITLE
settings: disable autocorrect and spellcheck on s3 settings inputs

### DIFF
--- a/ui/src/preferences/StoragePrefs.tsx
+++ b/ui/src/preferences/StoragePrefs.tsx
@@ -109,6 +109,7 @@ export const StoragePrefs = () => {
             id="key"
             type="text"
             autoCorrect="off"
+            spellCheck="false"
             defaultValue={s3.credentials?.accessKeyId}
             {...register('accessId', { required: true })}
             className="input default-ring bg-gray-50"
@@ -124,6 +125,7 @@ export const StoragePrefs = () => {
             id="secretAccessKey"
             type="text"
             autoCorrect="off"
+            spellCheck="false"
             defaultValue={s3.credentials?.secretAccessKey}
             {...register('accessSecret', { required: true })}
             className="input default-ring bg-gray-50"

--- a/ui/src/preferences/StoragePrefs.tsx
+++ b/ui/src/preferences/StoragePrefs.tsx
@@ -92,7 +92,7 @@ export const StoragePrefs = () => {
             disabled={!loaded}
             required
             id="endpoint"
-            type="text"
+            type="url"
             defaultValue={s3.credentials?.endpoint}
             {...register('endpoint', { required: true })}
             className="input default-ring bg-gray-50"

--- a/ui/src/preferences/StoragePrefs.tsx
+++ b/ui/src/preferences/StoragePrefs.tsx
@@ -93,6 +93,7 @@ export const StoragePrefs = () => {
             required
             id="endpoint"
             type="url"
+            autoCorrect="off"
             defaultValue={s3.credentials?.endpoint}
             {...register('endpoint', { required: true })}
             className="input default-ring bg-gray-50"
@@ -107,6 +108,7 @@ export const StoragePrefs = () => {
             required
             id="key"
             type="text"
+            autoCorrect="off"
             defaultValue={s3.credentials?.accessKeyId}
             {...register('accessId', { required: true })}
             className="input default-ring bg-gray-50"
@@ -121,6 +123,7 @@ export const StoragePrefs = () => {
             required
             id="secretAccessKey"
             type="text"
+            autoCorrect="off"
             defaultValue={s3.credentials?.secretAccessKey}
             {...register('accessSecret', { required: true })}
             className="input default-ring bg-gray-50"
@@ -135,6 +138,7 @@ export const StoragePrefs = () => {
             required
             id="region"
             type="text"
+            autoCorrect="off"
             defaultValue={s3.configuration?.region}
             {...register('region', { required: true })}
             className="input default-ring bg-gray-50"
@@ -149,6 +153,7 @@ export const StoragePrefs = () => {
             required
             id="bucket"
             type="text"
+            autoCorrect="off"
             defaultValue={s3.configuration.currentBucket}
             {...register('bucket', { required: true })}
             className="input default-ring bg-gray-50"


### PR DESCRIPTION
Intended to address #170

- **Changes input type of endpoint field to `url`** which should help hint to browsers what kind of value is expected.
- **Adds `spellcheck="false"` to Access Key fields** which are extremely unlikely to have spellcheck-able input. Does not set "off" for bucket name or regions which may have inputs that you'd want to spellcheck. Personally, I'm not confident enough to turn it off for that reason.
- **Adds `autocorrect="off"` to all fields** this is a Safari extension, but other browsers may respect it as well. I think it's often-enough unhelpful for fields like this that disabling it is safe.

⚠️ I am not sure I set up the `landscape` dev environment 100% correctly, and when I test this locally with the vite proxy through `npm run dev` all the inputs on this settings panel are unfousable - both before and after the changes in this PR.