### PR TITLE
added Trill to app recommendation list

### DIFF
--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -67,6 +67,15 @@ export const APPS = [
     desk: 'scooore',
   },
   {
+    title: "Trill",
+    description: "Twitter without limits, and much more",
+    color: '#FFD400',
+    link: '/apps/trill',
+    section: SECTIONS.PALS,
+    desk: 'trill',
+    source: '~dister-dozzod-sortug'
+  },
+  {
     title: 'Docs',
     description: 'User and developer documentation for Urbit apps',
     color: '#FFCF00',


### PR DESCRIPTION
Humbly request adding Trill, now integrating Tlon Chat and Pals, to the list of recommended apps in Garden.

Now that Twitter operations are tumbling it's good timing to remind people of just how smooth Urbit is at running social media apps. Trill now has Global Feeds which aid greatly in content and user discovery in the network.