### PR TITLE
docket: notify on long-running app install

### DIFF
--- a/desk/app/treaty.hoon
+++ b/desk/app/treaty.hoon
@@ -130,6 +130,7 @@
     [%x %alliance ~]      ``(alliance-update:cg:ca %ini entente)
     [%x %default-ally ~]  ``ship+!>(default-ally)
     [%x %allies ~]        ``(ally-update:cg:ca %ini allies)
+    [%x %treaties ~]      ``(treaty-update:cg:ca:cc %ini treaties)
   ::
      [%x %treaties @ ~]
     =/  =ship  (slav %p i.t.t.path)

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -13,7 +13,6 @@ import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { ErrorBoundary } from 'react-error-boundary';
 import FingerprintJS from '@fingerprintjs/fingerprintjs';
 import { Grid } from './pages/Grid';
-import useDocketState from './state/docket';
 import { PermalinkRoutes } from './pages/PermalinkRoutes';
 import useKilnState from './state/kiln';
 import useContactState from './state/contact';
@@ -23,6 +22,7 @@ import { useBrowserId, useLocalState } from './state/local';
 import { ErrorAlert } from './components/ErrorAlert';
 import { useErrorHandler } from './logic/useErrorHandler';
 import useSchedulerStore, { useScheduler } from './state/scheduler';
+import bootstrap from './state/bootstrap';
 
 const getNoteRedirect = (path: string) => {
   if (path.startsWith('/desk/')) {
@@ -91,11 +91,7 @@ const AppRoutes = () => {
     handleError(() => {
       window.name = 'grid';
 
-      const { fetchDefaultAlly, fetchAllies, fetchCharges } =
-        useDocketState.getState();
-      fetchDefaultAlly();
-      fetchCharges();
-      fetchAllies();
+      bootstrap();
 
       const { initializeKiln } = useKilnState.getState();
       initializeKiln();

--- a/ui/src/components/AppInfo.tsx
+++ b/ui/src/components/AppInfo.tsx
@@ -8,7 +8,11 @@ import { DialogClose, DialogContent, DialogTrigger } from './Dialog';
 import { DocketHeader } from './DocketHeader';
 import { Spinner } from './Spinner';
 import { PikeMeta } from './PikeMeta';
-import useDocketState, { ChargeWithDesk, useTreaty } from '../state/docket';
+import {
+  ChargeWithDesk,
+  useInstallDocketMutation,
+  useTreaty,
+} from '../state/docket';
 import { getAppHref, getAppName } from '@/logic/utils';
 import { addRecentApp } from '../nav/search/Home';
 import { TreatyMeta } from './TreatyMeta';
@@ -58,12 +62,14 @@ export const AppInfo: FC<AppInfoProps> = ({
   const publisher = pike?.sync?.ship ?? ship;
   const [copied, setCopied] = useState(false);
   const treaty = useTreaty(ship, desk);
+  const { mutate: installDocketMutation } = useInstallDocketMutation();
 
   const installApp = async () => {
     if (installStatus === 'installed') {
       return;
     }
-    await useDocketState.getState().installDocket(ship, desk);
+
+    installDocketMutation({ ship, desk });
   };
 
   const copyApp = useCallback(() => {

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -92,7 +92,7 @@ export const APPS = [
     link: '/apps/quorom',
     section: SECTIONS.DEV,
     desk: 'quorum',
-    source: '~dister-dister-sidynm-ladrut',
+    source: '~dister-dister-sidnym-ladrut',
     image: 'https://ladrut.xyz/quorum/quorum-logo.png',
   },
   {

--- a/ui/src/gear/hark/types.ts
+++ b/ui/src/gear/hark/types.ts
@@ -96,6 +96,11 @@ export interface HarkUpdate {
   threads: Threads;
 }
 
+export interface NewYarn extends Omit<Yarn, 'id' | 'time'> {
+  all: boolean;
+  desk: boolean;
+}
+
 export interface Skein {
   time: number;
   count: number;

--- a/ui/src/gear/hark/types.ts
+++ b/ui/src/gear/hark/types.ts
@@ -89,6 +89,7 @@ export interface HarkSawRope {
 }
 
 export type HarkAction = HarkAddYarn | HarkSawSeam | HarkSawRope;
+export type HarkAction1 = HarkAddNewYarn | HarkAction;
 
 export interface HarkUpdate {
   yarns: Yarns;
@@ -99,6 +100,10 @@ export interface HarkUpdate {
 export interface NewYarn extends Omit<Yarn, 'id' | 'time'> {
   all: boolean;
   desk: boolean;
+}
+
+export interface HarkAddNewYarn {
+  'new-yarn': NewYarn;
 }
 
 export interface Skein {

--- a/ui/src/logic/useReactQuerySubscribeOnce.ts
+++ b/ui/src/logic/useReactQuerySubscribeOnce.ts
@@ -1,0 +1,31 @@
+import api from '@/api';
+import { QueryKey, useQuery, UseQueryOptions } from '@tanstack/react-query';
+
+export default function useReactQuerySubscribeOnce<T>({
+  queryKey,
+  app,
+  path,
+  options,
+  initialData,
+  timeout = 5000,
+}: {
+  queryKey: QueryKey;
+  app: string;
+  path: string;
+  options?: UseQueryOptions;
+  initialData?: any;
+  timeout?: number;
+}): ReturnType<typeof useQuery> {
+  const fetchData = async () => api.subscribeOnce<T>(app, path, timeout);
+
+  const defaultOptions = {
+    retryOnMount: false,
+    refetchOnMount: false,
+    enabled: true,
+    initialData,
+  };
+  return useQuery(queryKey, fetchData, {
+    ...defaultOptions,
+    ...options,
+  });
+}

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -94,7 +94,9 @@ export function isColor(color: string): boolean {
 export const makeBrowserNotification = (yarn: Yarn) => {
   const rope = yarn.rope;
   // need to capitalize desk name
-  const app = rope?.desk.slice(0, 1).toUpperCase() + rope?.desk.slice(1);
+  const app = rope
+    ? rope?.desk.slice(0, 1).toUpperCase() + rope?.desk.slice(1)
+    : '';
   const { con } = yarn;
   const ship = con.find(isYarnShip)?.ship || '';
   const emph = con.find(isYarnEmph)?.emph || '';

--- a/ui/src/nav/notifications/Notification.tsx
+++ b/ui/src/nav/notifications/Notification.tsx
@@ -232,11 +232,16 @@ const NotificationContent: React.FC<NotificationContent> = ({
 export default function Notification({ bin, groups }: NotificationProps) {
   const moreCount = bin.count;
   const { rope, con, wer, but } = bin.top;
-  const charge = useCharge(rope.desk);
+  const charge = useCharge(rope?.desk ?? '');
   const app = getAppName(charge);
+  const { mutate: sawRope } = useSawRopeMutation();
+
+  if (!rope) {
+    return null;
+  }
+
   const type = getNotificationType(rope);
   const ship = con.find(isYarnShip)?.ship;
-  const { mutate: sawRope } = useSawRopeMutation();
 
   const onClick = useCallback(() => {
     console.log('clearing notification', rope);

--- a/ui/src/nav/search/Home.tsx
+++ b/ui/src/nav/search/Home.tsx
@@ -11,9 +11,10 @@ import { ProviderList } from '../../components/ProviderList';
 import { AppLink } from '../../components/AppLink';
 import { ShipName } from '../../components/ShipName';
 import { ProviderLink } from '../../components/ProviderLink';
-import useDocketState, {
+import {
   ChargesWithDesks,
   useCharges,
+  useDefaultAlly,
 } from '../../state/docket';
 import {
   clearStorageMigration,
@@ -98,14 +99,11 @@ export const Home = () => {
   const charges = useCharges();
   const groups = charges?.landscape;
   const contacts = useContactState((s) => s.contacts);
-  const defaultAlly = useDocketState((s) =>
-    s.defaultAlly
-      ? {
-          shipName: s.defaultAlly,
-          ...(contacts[s.defaultAlly] || emptyContact),
-        }
-      : null
-  );
+  const defAlly = useDefaultAlly();
+  const defaultAlly = {
+    shipName: defAlly,
+    ...(contacts[defAlly] || emptyContact),
+  };
   const providerList = recentDevs.map((d) => ({
     shipName: d,
     ...(contacts[d] || emptyContact),

--- a/ui/src/nav/search/TreatyInfo.tsx
+++ b/ui/src/nav/search/TreatyInfo.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { AppInfo } from '../../components/AppInfo';
 import { Spinner } from '../../components/Spinner';
-import useDocketState, { useCharge, useTreaty } from '../../state/docket';
+import { useCharge, useTreaty } from '../../state/docket';
 import { usePike } from '../../state/kiln';
 import { getAppName } from '@/logic/utils';
 import { useAppSearchStore } from '../Nav';
@@ -19,12 +19,6 @@ export const TreatyInfo = () => {
   const name = treaty ? getAppName(treaty) : `${host}/${desk}`;
   const { data, showConnection } = useConnectivityCheck(host);
   const treatyNotFound = treaty === null && data && 'complete' in data.status;
-
-  useEffect(() => {
-    if (!charge) {
-      useDocketState.getState().requestTreaty(host, desk);
-    }
-  }, [host, desk]);
 
   useEffect(() => {
     select(<>{name}</>);

--- a/ui/src/state/bootstrap.ts
+++ b/ui/src/state/bootstrap.ts
@@ -1,0 +1,43 @@
+import api from '@/api';
+import queryClient from '@/query-client';
+import {
+  AllyUpdateIni,
+  ChargeUpdateInitial,
+  scryAllies,
+  scryCharges,
+  scryDefaultAlly,
+} from '@/gear';
+import { ChargesWithDesks, ChargeWithDesk, normalizeDocket } from './docket';
+
+const fetchCharges = async () => {
+  const charg = (await api.scry<ChargeUpdateInitial>(scryCharges)).initial;
+
+  const charges = Object.entries(charg).reduce(
+    (obj: ChargesWithDesks, [key, value]) => {
+      // eslint-disable-next-line no-param-reassign
+      obj[key] = normalizeDocket(value as ChargeWithDesk, key);
+      return obj;
+    },
+    {}
+  );
+
+  queryClient.setQueryData(['charges'], charges);
+};
+
+const fetchDefaultAlly = async () => {
+  const defaultAlly = await api.scry<string>(scryDefaultAlly);
+
+  queryClient.setQueryData(['defaultAlly'], defaultAlly);
+};
+
+const fetchAllies = async () => {
+  const allies = (await api.scry<AllyUpdateIni>(scryAllies)).ini;
+
+  queryClient.setQueryData(['allies'], allies);
+};
+
+export default function bootstrap() {
+  fetchCharges();
+  fetchDefaultAlly();
+  fetchAllies();
+}

--- a/ui/src/state/hark.ts
+++ b/ui/src/state/hark.ts
@@ -1,5 +1,13 @@
 import _ from 'lodash';
-import { HarkAction, NewYarn, Rope, Seam, Skein, Yarn } from '@/gear';
+import {
+  HarkAction,
+  HarkAction1,
+  NewYarn,
+  Rope,
+  Seam,
+  Skein,
+  Yarn,
+} from '@/gear';
 import useReactQuerySubscription from '@/logic/useReactQuerySubscription';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { SettingsState } from './settings';
@@ -117,19 +125,21 @@ interface NewYarnData extends Omit<NewYarn, 'all' | 'desk' | 'rope'> {
 export function useAddYarnMutation() {
   const queryClient = useQueryClient();
   const mutationFn = async (variables: { newYarn: NewYarnData }) => {
-    return api.poke<NewYarn>({
+    return api.poke<HarkAction1>({
       app: 'hark',
-      mark: 'hark-new-yarn',
+      mark: 'hark-action-1',
       json: {
-        all: true,
-        desk: true,
-        rope: {
-          desk: window.desk,
-          group: null,
-          channel: null,
-          thread: '/apps',
+        'new-yarn': {
+          all: true,
+          desk: true,
+          rope: {
+            desk: window.desk,
+            group: null,
+            channel: null,
+            thread: '/apps',
+          },
+          ...variables.newYarn,
         },
-        ...variables.newYarn,
       },
     });
   };

--- a/ui/src/state/watcher.ts
+++ b/ui/src/state/watcher.ts
@@ -1,0 +1,28 @@
+import produce from 'immer';
+import create from 'zustand';
+
+export type Watcher = {
+  time: number;
+};
+
+export type WatcherState = {
+  watchers: Record<string, Watcher>;
+  addWatcher: (key: string, watcher: Watcher) => void;
+  removeWatcher: (key: string) => void;
+};
+
+export const useWatcherStore = create<WatcherState>((set) => ({
+  watchers: {},
+  addWatcher: (key, watcher) =>
+    set(
+      produce((state) => {
+        state.watchers[key] = watcher;
+      })
+    ),
+  removeWatcher: (key) =>
+    set(
+      produce((state) => {
+        delete state.watchers[key];
+      })
+    ),
+}));

--- a/ui/src/tiles/RemoveApp.tsx
+++ b/ui/src/tiles/RemoveApp.tsx
@@ -3,7 +3,10 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { Button } from '../components/Button';
 import { Dialog, DialogClose, DialogContent } from '../components/Dialog';
 import { useRecentsStore } from '../nav/search/Home';
-import useDocketState, { useCharges } from '../state/docket';
+import {
+  useCharges,
+  useUninstallDocketMutation,
+} from '../state/docket';
 import { getAppName } from '@/logic/utils';
 
 export const RemoveApp = () => {
@@ -11,11 +14,11 @@ export const RemoveApp = () => {
   const { desk = '' } = useParams<{ desk: string }>();
   const charges = useCharges();
   const docket = charges[desk];
-  const uninstallDocket = useDocketState((s) => s.uninstallDocket);
+  const { mutate: uninstallDocket } = useUninstallDocketMutation();
 
   // TODO: add optimistic updates
   const handleRemoveApp = useCallback(() => {
-    uninstallDocket(desk);
+    uninstallDocket({ desk });
     useRecentsStore.getState().removeRecentApp(desk);
   }, [desk]);
 

--- a/ui/src/tiles/SuspendApp.tsx
+++ b/ui/src/tiles/SuspendApp.tsx
@@ -3,7 +3,10 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { Button } from '../components/Button';
 import { Dialog, DialogClose, DialogContent } from '../components/Dialog';
 import { useRecentsStore } from '../nav/search/Home';
-import useDocketState, { useCharges } from '../state/docket';
+import {
+  useCharges,
+  useToggleDocketMutation,
+} from '../state/docket';
 import { getAppName } from '@/logic/utils';
 
 export const SuspendApp = () => {
@@ -11,10 +14,11 @@ export const SuspendApp = () => {
   const { desk = '' } = useParams<{ desk: string }>();
   const charges = useCharges();
   const charge = charges[desk];
+  const { mutate: toggleDocket } = useToggleDocketMutation();
 
   // TODO: add optimistic updates
   const handleSuspendApp = useCallback(() => {
-    useDocketState.getState().toggleDocket(desk);
+    toggleDocket({ desk });
     useRecentsStore.getState().removeRecentApp(desk);
   }, [desk]);
 

--- a/ui/src/tiles/TileMenu.tsx
+++ b/ui/src/tiles/TileMenu.tsx
@@ -1,9 +1,9 @@
-import React, { ReactElement, useCallback, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 import { Chad, chadIsRunning } from '@/gear';
-import useDocketState from '../state/docket';
+import { useToggleDocketMutation } from '../state/docket';
 import { disableDefault, handleDropdownLink } from '@/logic/utils';
 import { useMedia } from '../logic/useMedia';
 
@@ -43,7 +43,7 @@ export const TileMenu = ({
   className,
 }: TileMenuProps) => {
   const [open, setOpen] = useState(false);
-  const toggleDocket = useDocketState((s) => s.toggleDocket);
+  const { mutate: toggleDocket } = useToggleDocketMutation();
   const menuBg = { backgroundColor: menuColor };
   const linkOnSelect = useCallback(handleDropdownLink(setOpen), []);
   const active = chadIsRunning(chad);
@@ -105,7 +105,7 @@ export const TileMenu = ({
               </Item>
             )}
             {suspended && (
-              <Item onSelect={() => toggleDocket(desk)}>
+              <Item onSelect={() => toggleDocket({ desk })}>
                 <span className="block w-full px-4 py-3">Resume App</span>
               </Item>
             )}

--- a/ui/src/window.ts
+++ b/ui/src/window.ts
@@ -1,6 +1,5 @@
 import { useAppSearchStore } from './nav/Nav';
 import { useRecentsStore } from './nav/search/Home';
-import useDocketState from './state/docket';
 
 declare global {
   interface Window {
@@ -8,7 +7,6 @@ declare global {
     desk: string;
     our: string;
     recents: typeof useRecentsStore.getState;
-    docket: typeof useDocketState.getState;
     appSearch: typeof useAppSearchStore.getState;
   }
 }


### PR DESCRIPTION
new version of @patosullivan 's PR #192 with latest develop and updated for changes to [tloncorp/landscape#2574](https://github.com/tloncorp/landscape-apps/pull/2574)

> Adds a mutation to create a yarn from the frontend.
Adds a new zustand state for tracking actions that could take a while (WatcherStore).
Switches docket over to react-query (added a new scry endpoint as part of this).
Adds a bootstrap script that we can start to use incrementally.
Fixes a misspelling in constants for the ship hosting Quorum.
Fixes some type issues around the new Yarn type.
Closes https://github.com/tloncorp/landscape/issues/154
Fixes LAND-505

This is dependent on https://github.com/tloncorp/landscape-apps/pull/2574