### PR TITLE
update wayfinding to reference Tlon Local

### DIFF
--- a/ui/src/components/LandscapeWayfinding.tsx
+++ b/ui/src/components/LandscapeWayfinding.tsx
@@ -30,9 +30,9 @@ const groups: Record<string, Group> = {
     link: '/apps/groups/groups/~natnex-ronret/door-link',
   },
   tlonPublic: {
-    title: 'Tlon Public',
+    title: 'Tlon Local',
     description: 'A place to ask for help',
-    icon: 'https://sfo3.digitaloceanspaces.com/zurbit-images/dovsem-bornyl/2022.6.16..19.11.20-flooring.jpeg',
+    icon: 'https://nyc3.digitaloceanspaces.com/fabled-faster/fabled-faster/2023.4.06..02.45.31-bg.jpg',
     color: 'bg-yellow-500',
     link: '/apps/groups/groups/~nibset-napwyn/tlon',
   },

--- a/ui/src/nav/Help.tsx
+++ b/ui/src/nav/Help.tsx
@@ -41,7 +41,7 @@ const groups: Record<string, Group> = {
     link: '/apps/groups/groups/~bitpyx-dildus/tlon-support',
   },
   tlonPublic: {
-    title: 'Tlon Public',
+    title: 'Tlon Local',
     icon: 'https://sfo3.digitaloceanspaces.com/zurbit-images/dovsem-bornyl/2022.6.16..19.11.20-flooring.jpeg',
     color: 'bg-yellow-500',
     link: '/apps/groups/groups/~nibset-napwyn/tlon',


### PR DESCRIPTION
Just noticed that the wayfinding helper references Tlon Public instead of Tlon Local; this fixes that.