### PR TITLE
bark: remove /sur/hark dependency from thread

### DIFF
--- a/desk/ted/save-summary.hoon
+++ b/desk/ted/save-summary.hoon
@@ -3,7 +3,7 @@
 ::    crashes on failure. on success, produces the result message from the
 ::    -mailchimp-update-merge-fields thread.
 ::
-/-  spider, hark
+/-  spider
 /+  *strandio
 =,  strand=strand:spider
 =,  dejs:format


### PR DESCRIPTION
The "save summary" thread still had hark flagged as one of its dependencies, but doesn't actually use that for anything anymore.

Here we simply remove the import.

(Already hand-deployed onto the bark service ship, no particular rush in getting this out.)