### PR TITLE
lib: avoid crash during activity summarization

### DIFF
--- a/desk/lib/summarize.hoon
+++ b/desk/lib/summarize.hoon
@@ -86,14 +86,15 @@
   ::      group. simply skip past it and try the next one...
   =+  .^  =groups:groups
         %gx
-        =-  ~&  [%scrying -]  -
         (scry-path %groups /groups/groups)
       ==
   |-
   ?~  faz  ['???' '???']  ::TODO  better copy
+  ~|  i.faz
   ?.  (~(has by groups) g.i.faz)
     $(faz t.faz)
   =/  =group:^groups  (~(got by groups) g.i.faz)
-  :-  title.meta.group
-  title.meta:(~(got by channels.group) %chat c.i.faz)
+  ?~  chat=(~(get by channels.group) %chat c.i.faz)
+    $(faz t.faz)
+  [title.meta.group title.meta.u.chat]
 --


### PR DESCRIPTION
There is a (somewhat poorly understood, cc @arthyn: thoughts?) case where the group associated with a chat may not actually contain that chat in its channels listing.

Here, instead of assuming the channel is always present, we ask for it more gently, and simply skip to the next-most-active channel if it turns out to be missing.

We also remove a stray debug printf, and add a trace print in case anything else goes wrong here.