### PR TITLE
bark: correctly handle save-summary thread results

### DIFF
--- a/desk/app/bark.hoon
+++ b/desk/app/bark.hoon
@@ -113,7 +113,8 @@
 ++  on-agent  on-agent:def
 ++  on-fail
   |=  [=term =tang]
-  (mean ':sub +on-fail' term tang)
+  %-  (slog 'bark: on-fail' term tang)
+  [~ this]
 ++  on-leave
   |=  =path
   `this

--- a/desk/app/bark.hoon
+++ b/desk/app/bark.hoon
@@ -39,12 +39,20 @@
 ++  on-arvo
   |=  [=wire sign=sign-arvo]
   ^-  (quip card _this)
-  ?>  =(/fetch wire)
-  ?>  ?=(%wake +<.sign)
-  =^  caz  this  (on-poke %bark-generate-summaries !>(~))
-  :_  this
-  :_  caz
-  [%pass /fetch %arvo %b %wait (next-timer now.bowl)]
+  ?+  wire  ~|([%strange-wire wire] !!)
+      [%fetch ~]
+    ?>  ?=(%wake +<.sign)
+    =^  caz  this  (on-poke %bark-generate-summaries !>(~))
+    :_  this
+    :_  caz
+    [%pass /fetch %arvo %b %wait (next-timer now.bowl)]
+  ::
+      [%save-summary @ @ ~]
+    ?>  ?=(%arow +<.sign)
+    ?:  ?=(%& -.p.sign)  [~ this]
+    %-  (slog 'bark: failed to save summary' p.p.sign)
+    [~ this]
+  ==
 ::
 ++  on-poke
   |=  [=mark =vase]

--- a/desk/ted/save-summary.hoon
+++ b/desk/ted/save-summary.hoon
@@ -35,7 +35,8 @@
 ::
 =/  [%khan %arow %.y %noun vs=vase]  mine
 =+  !<(mail=(unit cord) vs)
-?>  ?=(^ mail)
+?~  mail
+  (pure:m !>('no-mail'))
 ;<  ~  bind:m
   %-  send-raw-card
   :*  %pass  /update-merge-fields/(scot %p ship.args)


### PR DESCRIPTION
We weren't accounting for the different wire used for this, causing us to spill our spaghetti and redirect processing to `+on-fail`, which wasn't very graceful.

This didn't impact the threads/functionality itself, only bark's non-existent bookkeeping. The crash went into `+on-fail`, which was crashing in turn.

With this change, we can actually properly notify (in the terminal (; ) on failed thread runs.