### PR TITLE
hark: bad copy from groups

### DIFF
--- a/desk/lib/groups-json.hoon
+++ b/desk/lib/groups-json.hoon
@@ -16,6 +16,6 @@
   |%
   ++  ship  (se %p)
   ++  flag  (su ;~((glue fas) ;~(pfix sig fed:ag) sym))
-  ++  nest  (su ;~((glue fas) sym ;~(pfix sig fed:ag)))
+  ++  nest  (su ;~((glue fas) sym ;~(pfix sig fed:ag) sym))
   --
 --

--- a/desk/lib/hark-json.hoon
+++ b/desk/lib/hark-json.hoon
@@ -153,19 +153,18 @@
 ++  dejs
   =,  dejs:format
   |%
+  ++  action-tags
+    :~  saw-seam/seam
+        saw-rope/rope
+        add-yarn/add-yarn
+    ==
   ++  action
-    %-  of
-    :~  saw-seam/seam
-        saw-rope/rope
-        add-yarn/add-yarn
-    ==
+    ^-  $-(json action:h)
+    (of action-tags)
+  ::
   ++  action-1
-    %-  of
-    :~  saw-seam/seam
-        saw-rope/rope
-        add-yarn/add-yarn
-        new-yarn/new-yarn
-    ==
+    ^-  $-(json action-1:h)
+    (of new-yarn/new-yarn action-tags)
   ::
   ++  seam
     %-  of


### PR DESCRIPTION
This fixes LAND-849 by properly copying the dejs function for nests. Also updates the json lib to match what was in groups.