### PR TITLE
storage: add token-based upload for hosting

### DIFF
--- a/desk/app/storage.hoon
+++ b/desk/app/storage.hoon
@@ -10,13 +10,15 @@
 +$  versioned-state
   $%  state-zero
       state-one
+      state-two
   ==
 ::
 +$  state-zero  [%0 =credentials:zero:past =configuration:zero:past]
-+$  state-one   [%1 =credentials =configuration]
++$  state-one   [%1 =credentials:one:past =configuration:one:past]
++$  state-two   [%2 =credentials =configuration]
 --
 ::
-=|  state-one
+=|  state-two
 =*  state  -
 ::
 %-  agent:dbug
@@ -41,13 +43,15 @@
 ++  on-save  !>(state)
 ++  on-load
   |=  =vase
+  |^
   =/  old  ((soft versioned-state) q.vase)
   ?~  old  on-init
   =/  old  u.old
-  |^
+  |-
   ?-  -.old
-    %1  `this(state old)
-    %0  `this(state (state-0-to-1 old))
+    %0  $(old (state-0-to-1 old))
+    %1  $(old (state-1-to-2 old))
+    %2  `this(state old)
   ==
   ++  state-0-to-1
     |=  zer=state-zero
@@ -56,12 +60,31 @@
         credentials.zer
         (configuration-0-to-1 configuration.zer)
     ==
+  ::
   ++  configuration-0-to-1
     |=  conf=configuration:zero:past
-    ^-  ^configuration
+    ^-  configuration:one:past
     :*  buckets.conf
         current-bucket.conf
         ''
+    ==
+  ::
+  ++  state-1-to-2
+    |=  one=state-one
+    ^-  state-two
+    :*  %2
+        credentials.one
+        (configuration-1-to-2 configuration.one)
+    ==
+  ::
+  ++  configuration-1-to-2
+    |=  conf=configuration:one:past
+    ^-  ^configuration
+    :*  buckets.conf
+        current-bucket.conf
+        region.conf
+        ''
+        %credentials
     ==
   --
 ::
@@ -127,6 +150,12 @@
     ::
         %remove-bucket
       state(buckets.configuration (~(del in buckets.configuration) bucket.act))
+    ::
+        %set-presigned-url
+      state(presigned-url.configuration url.act)
+    ::
+        %toggle-service
+      state(service.configuration service.act)
     ==
   --
 ::

--- a/desk/lib/storage-json.hoon
+++ b/desk/lib/storage-json.hoon
@@ -14,6 +14,8 @@
         [%add-bucket so:dejs]
         [%remove-bucket so:dejs]
         [%set-current-bucket so:dejs]
+        [%set-presigned-url so:dejs]
+        [%toggle-service (su:dejs (perk %presigned-url %credentials ~))]
     ==
   --
 ::
@@ -30,6 +32,8 @@
           %remove-bucket       [%'removeBucket' s+bucket.upd]
           %set-endpoint        [%'setEndpoint' s+endpoint.upd]
           %set-access-key-id   [%'setAccessKeyId' s+access-key-id.upd]
+          %set-presigned-url   [%'setPresignedUrl' s+url.upd]
+          %toggle-service      [%'toggleService' s+service.upd]
           %set-secret-access-key
         [%'setSecretAccessKey' s+secret-access-key.upd]
       ::
@@ -47,6 +51,8 @@
         :~  [%buckets a+(turn ~(tap in buckets.configuration.upd) |=(a=@t s+a))]
             [%'currentBucket' s+current-bucket.configuration.upd]
             [%'region' s+region.configuration.upd]
+            [%'service' s+service.configuration.upd]
+            [%'presignedUrl' s+presigned-url.configuration.upd]
         ==
       ==
   ==

--- a/desk/sur/storage-1.hoon
+++ b/desk/sur/storage-1.hoon
@@ -1,31 +1,14 @@
-/-  zer=storage-0, uno=storage-1
 |%
-++  past
-  |%
-  ++  zero  zer
-  ++  one   uno
-  --
-+$  service  ?(%presigned-url %credentials)
 +$  credentials
   $:  endpoint=@t
       access-key-id=@t
       secret-access-key=@t
   ==
 ::
-::  $configuration: the upload configuration
-::
-::    $buckets: the buckets available
-::    $current-bucket: the current bucket we use to upload
-::    $region: the region of the current bucket
-::    $presigned-url: the presigned url endpoint
-::    $service: whether to use a presigned url service or direct S3 uploads
-::
 +$  configuration
   $:  buckets=(set @t)
       current-bucket=@t
       region=@t
-      presigned-url=@t
-      =service
   ==
 ::
 +$  action
@@ -36,8 +19,6 @@
       [%remove-bucket bucket=@t]
       [%set-current-bucket bucket=@t]
       [%set-region region=@t]
-      [%set-presigned-url url=@t]
-      [%toggle-service =service]
   ==
 ::
 +$  update

--- a/ui/src/gear/storage/lib.ts
+++ b/ui/src/gear/storage/lib.ts
@@ -1,52 +1,75 @@
 import { Poke } from '@urbit/http-api';
-import { StorageUpdate, StorageUpdateCurrentBucket, StorageUpdateAddBucket, StorageUpdateRemoveBucket, StorageUpdateEndpoint, StorageUpdateAccessKeyId, StorageUpdateSecretAccessKey, StorageUpdateRegion } from './types';
+import {
+  StorageUpdate,
+  StorageUpdateCurrentBucket,
+  StorageUpdateAddBucket,
+  StorageUpdateRemoveBucket,
+  StorageUpdateEndpoint,
+  StorageUpdateAccessKeyId,
+  StorageUpdateSecretAccessKey,
+  StorageUpdateRegion,
+  StorageService,
+  StorageUpdateSetPresignedUrl,
+  StorageUpdateToggleService,
+} from './types';
 
-const storageAction = <T extends StorageUpdate>(
-  data: any
-): Poke<T> => ({
+const storageAction = <T extends StorageUpdate>(data: any): Poke<T> => ({
   app: 'storage',
   mark: 'storage-action',
-  json: data
+  json: data,
 });
 
 export const setCurrentBucket = (
   bucket: string
-): Poke<StorageUpdateCurrentBucket> => storageAction({
-  'set-current-bucket': bucket
-});
+): Poke<StorageUpdateCurrentBucket> =>
+  storageAction({
+    'set-current-bucket': bucket,
+  });
 
-export const addBucket = (
-  bucket: string
-): Poke<StorageUpdateAddBucket> => storageAction({
-  'add-bucket': bucket
-});
+export const addBucket = (bucket: string): Poke<StorageUpdateAddBucket> =>
+  storageAction({
+    'add-bucket': bucket,
+  });
 
-export const removeBucket = (
-  bucket: string
-): Poke<StorageUpdateRemoveBucket> => storageAction({
-  'remove-bucket': bucket
-});
+export const removeBucket = (bucket: string): Poke<StorageUpdateRemoveBucket> =>
+  storageAction({
+    'remove-bucket': bucket,
+  });
 
-export const setEndpoint = (
-  endpoint: string
-): Poke<StorageUpdateEndpoint> => storageAction({
-  'set-endpoint': endpoint
-});
+export const setEndpoint = (endpoint: string): Poke<StorageUpdateEndpoint> =>
+  storageAction({
+    'set-endpoint': endpoint,
+  });
 
 export const setAccessKeyId = (
   accessKeyId: string
-): Poke<StorageUpdateAccessKeyId> => storageAction({
-  'set-access-key-id': accessKeyId
-});
+): Poke<StorageUpdateAccessKeyId> =>
+  storageAction({
+    'set-access-key-id': accessKeyId,
+  });
 
 export const setSecretAccessKey = (
   secretAccessKey: string
-): Poke<StorageUpdateSecretAccessKey> => storageAction({
-  'set-secret-access-key': secretAccessKey
-});
+): Poke<StorageUpdateSecretAccessKey> =>
+  storageAction({
+    'set-secret-access-key': secretAccessKey,
+  });
 
-export const setRegion = (
-  region: string
-): Poke<StorageUpdateRegion> => storageAction({
-  'set-region': region
-})
+export const setRegion = (region: string): Poke<StorageUpdateRegion> =>
+  storageAction({
+    'set-region': region,
+  });
+
+export const setPresignedUrl = (
+  presignedUrl: string
+): Poke<StorageUpdateSetPresignedUrl> =>
+  storageAction({
+    'set-presigned-url': presignedUrl,
+  });
+
+export const toggleService = (
+  service: StorageService
+): Poke<StorageUpdateToggleService> =>
+  storageAction({
+    'toggle-service': service,
+  });

--- a/ui/src/gear/storage/types.ts
+++ b/ui/src/gear/storage/types.ts
@@ -2,34 +2,29 @@ import { S3Client } from '@aws-sdk/client-s3';
 
 export type Status = 'initial' | 'idle' | 'loading' | 'success' | 'error';
 
-export interface StorageConfigurationS3 {
+export type StorageService = 'presigned-url' | 'credentials';
+
+export interface StorageConfiguration {
   buckets: Set<string>;
   currentBucket: string;
   region: string;
+  presignedUrl: string;
+  service: StorageService;
 }
 
-export interface StorageCredentialsS3 {
+export interface StorageCredentials {
   endpoint: string;
   accessKeyId: string;
   secretAccessKey: string;
 }
 
-export interface StorageCredentialsTlonHosting {
-  endpoint: string;
-  token: string;
-}
-
-export type StorageBackend = 's3' | 'tlon-hosting';
-
 export interface BaseStorageState {
   loaded?: boolean;
   hasCredentials?: boolean;
-  backend: StorageBackend;
   s3: {
-    configuration: StorageConfigurationS3;
-    credentials: StorageCredentialsS3 | null;
+    configuration: StorageConfiguration;
+    credentials: StorageCredentials | null;
   };
-  tlonHosting: StorageCredentialsTlonHosting;
   [ref: string]: unknown;
 }
 
@@ -70,20 +65,21 @@ export interface Uploader {
 }
 
 export interface FileStore {
-  // Only one among S3 client or Tlon credentials will be set at a given time.
-  s3Client: S3Client | null;
-  tlonHostingCredentials: StorageCredentialsTlonHosting | null;
+  client: S3Client | null;
   uploaders: Record<string, Uploader>;
   getUploader: (key: string) => Uploader;
-  createS3Client: (s3: StorageCredentialsS3, region: string) => void;
-  setTlonHostingCredentials: (credentials: StorageCredentialsTlonHosting) => void;
+  createClient: (s3: StorageCredentials, region: string) => void;
   update: (key: string, updateFn: (uploader: Uploader) => void) => void;
   uploadFiles: (
     uploader: string,
     files: FileList | null,
-    bucket: string
+    config: StorageConfiguration
   ) => Promise<void>;
-  upload: (uploader: string, upload: Upload, bucket: string) => Promise<void>;
+  upload: (
+    uploader: string,
+    upload: Upload,
+    config: StorageConfiguration
+  ) => Promise<void>;
   clear: (uploader: string) => void;
   updateFile: (
     uploader: string,
@@ -100,8 +96,8 @@ export interface UploadInputProps {
   id: string;
 }
 
-export interface StorageUpdateCredentialsS3 {
-  credentials: StorageCredentialsS3;
+export interface StorageUpdateCredentials {
+  credentials: StorageCredentials;
 }
 
 export interface StorageUpdateConfiguration {
@@ -139,8 +135,16 @@ export interface StorageUpdateRegion {
   setRegion: string;
 }
 
+export interface StorageUpdateToggleService {
+  toggleService: string;
+}
+
+export interface StorageUpdateSetPresignedUrl {
+  setPresignedUrl: string;
+}
+
 export declare type StorageUpdate =
-  | StorageUpdateCredentialsS3
+  | StorageUpdateCredentials
   | StorageUpdateConfiguration
   | StorageUpdateCurrentBucket
   | StorageUpdateAddBucket
@@ -148,4 +152,6 @@ export declare type StorageUpdate =
   | StorageUpdateEndpoint
   | StorageUpdateAccessKeyId
   | StorageUpdateSecretAccessKey
-  | StorageUpdateRegion;
+  | StorageUpdateRegion
+  | StorageUpdateToggleService
+  | StorageUpdateSetPresignedUrl;

--- a/ui/src/gear/storage/types.ts
+++ b/ui/src/gear/storage/types.ts
@@ -2,7 +2,7 @@ import { S3Client } from '@aws-sdk/client-s3';
 
 export type Status = 'initial' | 'idle' | 'loading' | 'success' | 'error';
 
-export interface StorageCredentials {
+export interface StorageCredentialsS3 {
   endpoint: string;
   accessKeyId: string;
   secretAccessKey: string;
@@ -17,7 +17,7 @@ export interface BaseStorageState {
       currentBucket: string;
       region: string;
     };
-    credentials: StorageCredentials | null;
+    credentials: StorageCredentialsS3 | null;
   };
   [ref: string]: unknown;
 }
@@ -62,7 +62,7 @@ export interface FileStore {
   client: S3Client | null;
   uploaders: Record<string, Uploader>;
   getUploader: (key: string) => Uploader;
-  createClient: (s3: StorageCredentials, region: string) => void;
+  createClient: (s3: StorageCredentialsS3, region: string) => void;
   update: (key: string, updateFn: (uploader: Uploader) => void) => void;
   uploadFiles: (
     uploader: string,
@@ -86,8 +86,8 @@ export interface UploadInputProps {
   id: string;
 }
 
-export interface StorageUpdateCredentials {
-  credentials: StorageCredentials;
+export interface StorageUpdateCredentialsS3 {
+  credentials: StorageCredentialsS3;
 }
 
 export interface StorageUpdateConfiguration {
@@ -126,7 +126,7 @@ export interface StorageUpdateRegion {
 }
 
 export declare type StorageUpdate =
-  | StorageUpdateCredentials
+  | StorageUpdateCredentialsS3
   | StorageUpdateConfiguration
   | StorageUpdateCurrentBucket
   | StorageUpdateAddBucket

--- a/ui/src/preferences/StoragePrefs.tsx
+++ b/ui/src/preferences/StoragePrefs.tsx
@@ -39,7 +39,7 @@ export const StoragePrefs = () => {
   // XXX: The initial value should be set from the urbit.
   const [ storageType, setStorageType ] = useState<string>("s3");
 
-  const onStorageTypeChange = (event) =>
+  const onStorageTypeChange = (event: any) =>
     setStorageType(event.target.value);
 
   const {
@@ -85,7 +85,7 @@ export const StoragePrefs = () => {
             checked={storageType === "s3"}
             onChange={onStorageTypeChange}
           />
-          <label for="s3">S3</label><br/>
+          <label>S3</label><br/>
           <input
             type="radio"
             id="tlon-hosting"
@@ -93,7 +93,7 @@ export const StoragePrefs = () => {
             checked={storageType === "tlon-hosting"}
             onChange={onStorageTypeChange}
           />
-          <label for="tlon-hosting">Tlon Hosting</label><br/>
+          <label>Tlon Hosting</label><br/>
         </div>
       </div>
 

--- a/ui/src/preferences/StoragePrefs.tsx
+++ b/ui/src/preferences/StoragePrefs.tsx
@@ -67,7 +67,7 @@ export const StoragePrefs = () => {
     useCallback(() => {
       return api.trackedPoke<
         StorageUpdateToggleService,
-        { storageUpdate: StorageUpdate }
+        { 'storage-update': StorageUpdate }
       >(
         toggleService(hostedStorage ? 'credentials' : 'presigned-url'),
         { app: 'storage', path: '/all' },

--- a/ui/src/preferences/StoragePrefs.tsx
+++ b/ui/src/preferences/StoragePrefs.tsx
@@ -36,6 +36,12 @@ function storagePoke(data: S3Update | { 'set-region': string }) {
 export const StoragePrefs = () => {
   const { s3, loaded, ...storageState } = useStorage();
 
+  // XXX: The initial value should be set from the urbit.
+  const [ storageType, setStorageType ] = useState<string>("s3");
+
+  const onStorageTypeChange = (event) =>
+    setStorageType(event.target.value);
+
   const {
     register,
     handleSubmit,
@@ -71,125 +77,154 @@ export const StoragePrefs = () => {
           Configure your urbit to enable uploading your own images or other
           files in Urbit applications.
         </p>
-        <p>
-          Read more about setting up S3 storage in the{' '}
-          <a
-            className="font-bold"
-            rel="external"
-            target="_blank"
-            href="https://operators.urbit.org/manual/os/s3"
-          >
-            Urbit Operator's Manual
-          </a>
-          .
-        </p>
+        <div>
+          <input
+            type="radio"
+            id="s3"
+            value="s3"
+            checked={storageType === "s3"}
+            onChange={onStorageTypeChange}
+          />
+          <label for="s3">S3</label><br/>
+          <input
+            type="radio"
+            id="tlon-hosting"
+            value="tlon-hosting"
+            checked={storageType === "tlon-hosting"}
+            onChange={onStorageTypeChange}
+          />
+          <label for="tlon-hosting">Tlon Hosting</label><br/>
+        </div>
       </div>
-      <form onSubmit={handleSubmit(addS3Credentials)}>
-        <div className="mb-8 flex flex-col space-y-2">
-          <label className="font-semibold" htmlFor="endpoint">
-            Endpoint<span title="Required field">*</span>
-          </label>
-          <div className="relative">
-            <input
-              disabled={!loaded}
-              required
-              id="endpoint"
-              type="url"
-              autoCorrect="off"
-              defaultValue={s3.credentials?.endpoint}
-              {...register('endpoint', { required: true })}
-              className="input default-ring bg-gray-50"
-            />
-            {!loaded && <Spinner className="absolute top-1 right-2" />}
-          </div>
+
+      {storageType === "s3" ?
+        <div>
+          <p>
+            Read more about setting up S3 storage in the{' '}
+            <a
+              className="font-bold"
+              rel="external"
+              target="_blank"
+              href="https://operators.urbit.org/manual/os/s3"
+            >
+              Urbit Operator's Manual
+            </a>
+            .
+          </p>
+
+          <br/>
+
+          <form onSubmit={handleSubmit(addS3Credentials)}>
+            <div className="mb-8 flex flex-col space-y-2">
+              <label className="font-semibold" htmlFor="endpoint">
+                Endpoint<span title="Required field">*</span>
+              </label>
+              <div className="relative">
+                <input
+                  disabled={!loaded}
+                  required
+                  id="endpoint"
+                  type="url"
+                  autoCorrect="off"
+                  defaultValue={s3.credentials?.endpoint}
+                  {...register('endpoint', { required: true })}
+                  className="input default-ring bg-gray-50"
+                />
+                {!loaded && <Spinner className="absolute top-1 right-2" />}
+              </div>
+            </div>
+            <div className="mb-8 flex flex-col space-y-2">
+              <label className="font-semibold" htmlFor="key">
+                Access Key ID<span title="Required field">*</span>
+              </label>
+              <div className="relative">
+                <input
+                  disabled={!loaded}
+                  required
+                  id="key"
+                  type="text"
+                  autoCorrect="off"
+                  spellCheck="false"
+                  defaultValue={s3.credentials?.accessKeyId}
+                  {...register('accessId', { required: true })}
+                  className="input default-ring bg-gray-50"
+                />
+                {!loaded && <Spinner className="absolute top-1 right-2" />}
+              </div>
+            </div>
+            <div className="mb-8 flex flex-col space-y-2">
+              <label className="font-semibold" htmlFor="secretAccessKey">
+                Secret Access Key<span title="Required field">*</span>
+              </label>
+              <div className="relative">
+                <input
+                  disabled={!loaded}
+                  required
+                  id="secretAccessKey"
+                  type="text"
+                  autoCorrect="off"
+                  spellCheck="false"
+                  defaultValue={s3.credentials?.secretAccessKey}
+                  {...register('accessSecret', { required: true })}
+                  className="input default-ring bg-gray-50"
+                />
+                {!loaded && <Spinner className="absolute top-1 right-2" />}
+              </div>
+            </div>
+            <div className="mb-8 flex flex-col space-y-2">
+              <label className="font-semibold" htmlFor="region">
+                Region<span title="Required field">*</span>
+              </label>
+              <div className="relative">
+                <input
+                  disabled={!loaded}
+                  required
+                  id="region"
+                  type="text"
+                  autoCorrect="off"
+                  defaultValue={s3.configuration?.region}
+                  {...register('region', { required: true })}
+                  className="input default-ring bg-gray-50"
+                />
+                {!loaded && <Spinner className="absolute top-1 right-2" />}
+              </div>
+            </div>
+            <div className="mb-8 flex flex-col space-y-2">
+              <label className="font-semibold" htmlFor="bucket">
+                Bucket Name<span title="Required field">*</span>
+              </label>
+              <div className="relative">
+                <input
+                  disabled={!loaded}
+                  required
+                  id="bucket"
+                  type="text"
+                  autoCorrect="off"
+                  defaultValue={s3.configuration.currentBucket}
+                  {...register('bucket', { required: true })}
+                  className="input default-ring bg-gray-50"
+                />
+                {!loaded && <Spinner className="absolute top-1 right-2" />}
+              </div>
+            </div>
+            <Button
+              type="submit"
+              disabled={!isDirty || !isValid}
+              className={cn(
+                !isDirty || !isValid || isSubmitSuccessful
+                  ? 'cursor-not-allowed bg-gray-200 text-gray-100'
+                  : ''
+              )}
+            >
+              {isSubmitting ? <Spinner /> : 'Save'}
+              {isSubmitSuccessful && ' Successful'}
+            </Button>
+          </form>
+        </div> :
+        <div>
+          This configuration is handled by your hosting provider.
         </div>
-        <div className="mb-8 flex flex-col space-y-2">
-          <label className="font-semibold" htmlFor="key">
-            Access Key ID<span title="Required field">*</span>
-          </label>
-          <div className="relative">
-            <input
-              disabled={!loaded}
-              required
-              id="key"
-              type="text"
-              autoCorrect="off"
-              spellCheck="false"
-              defaultValue={s3.credentials?.accessKeyId}
-              {...register('accessId', { required: true })}
-              className="input default-ring bg-gray-50"
-            />
-            {!loaded && <Spinner className="absolute top-1 right-2" />}
-          </div>
-        </div>
-        <div className="mb-8 flex flex-col space-y-2">
-          <label className="font-semibold" htmlFor="secretAccessKey">
-            Secret Access Key<span title="Required field">*</span>
-          </label>
-          <div className="relative">
-            <input
-              disabled={!loaded}
-              required
-              id="secretAccessKey"
-              type="text"
-              autoCorrect="off"
-              spellCheck="false"
-              defaultValue={s3.credentials?.secretAccessKey}
-              {...register('accessSecret', { required: true })}
-              className="input default-ring bg-gray-50"
-            />
-            {!loaded && <Spinner className="absolute top-1 right-2" />}
-          </div>
-        </div>
-        <div className="mb-8 flex flex-col space-y-2">
-          <label className="font-semibold" htmlFor="region">
-            Region<span title="Required field">*</span>
-          </label>
-          <div className="relative">
-            <input
-              disabled={!loaded}
-              required
-              id="region"
-              type="text"
-              autoCorrect="off"
-              defaultValue={s3.configuration?.region}
-              {...register('region', { required: true })}
-              className="input default-ring bg-gray-50"
-            />
-            {!loaded && <Spinner className="absolute top-1 right-2" />}
-          </div>
-        </div>
-        <div className="mb-8 flex flex-col space-y-2">
-          <label className="font-semibold" htmlFor="bucket">
-            Bucket Name<span title="Required field">*</span>
-          </label>
-          <div className="relative">
-            <input
-              disabled={!loaded}
-              required
-              id="bucket"
-              type="text"
-              autoCorrect="off"
-              defaultValue={s3.configuration.currentBucket}
-              {...register('bucket', { required: true })}
-              className="input default-ring bg-gray-50"
-            />
-            {!loaded && <Spinner className="absolute top-1 right-2" />}
-          </div>
-        </div>
-        <Button
-          type="submit"
-          disabled={!isDirty || !isValid}
-          className={cn(
-            !isDirty || !isValid || isSubmitSuccessful
-              ? 'cursor-not-allowed bg-gray-200 text-gray-100'
-              : ''
-          )}
-        >
-          {isSubmitting ? <Spinner /> : 'Save'}
-          {isSubmitSuccessful && ' Successful'}
-        </Button>
-      </form>
+      }
     </div>
   );
 };

--- a/ui/src/state/storage/reducer.ts
+++ b/ui/src/state/storage/reducer.ts
@@ -6,7 +6,10 @@ import { BaseState } from '../base';
 
 export type StorageState = BaseStorageState & BaseState<BaseStorageState>;
 
-const credentials = (json: StorageUpdate, state: StorageState): StorageState => {
+const credentials = (
+  json: StorageUpdate,
+  state: StorageState
+): StorageState => {
   const data = _.get(json, 'credentials', false);
   if (data) {
     state.s3.credentials = data;
@@ -14,19 +17,27 @@ const credentials = (json: StorageUpdate, state: StorageState): StorageState => 
   return state;
 };
 
-const configuration = (json: StorageUpdate, state: StorageState): StorageState => {
+const configuration = (
+  json: StorageUpdate,
+  state: StorageState
+): StorageState => {
   const data = _.get(json, 'configuration', false);
   if (data) {
     state.s3.configuration = {
       buckets: new Set(data.buckets),
       currentBucket: data.currentBucket,
       region: data.region,
+      presignedUrl: data.presignedUrl,
+      service: data.service,
     };
   }
   return state;
 };
 
-const currentBucket = (json: StorageUpdate, state: StorageState): StorageState => {
+const currentBucket = (
+  json: StorageUpdate,
+  state: StorageState
+): StorageState => {
   const data = _.get(json, 'setCurrentBucket', false);
   if (data && state.s3) {
     state.s3.configuration.currentBucket = data;
@@ -42,7 +53,10 @@ const addBucket = (json: StorageUpdate, state: StorageState): StorageState => {
   return state;
 };
 
-const removeBucket = (json: StorageUpdate, state: StorageState): StorageState => {
+const removeBucket = (
+  json: StorageUpdate,
+  state: StorageState
+): StorageState => {
   const data = _.get(json, 'removeBucket', false);
   if (data) {
     state.s3.configuration.buckets.delete(data);
@@ -58,7 +72,10 @@ const endpoint = (json: StorageUpdate, state: StorageState): StorageState => {
   return state;
 };
 
-const accessKeyId = (json: StorageUpdate, state: StorageState): StorageState => {
+const accessKeyId = (
+  json: StorageUpdate,
+  state: StorageState
+): StorageState => {
   const data = _.get(json, 'setAccessKeyId', false);
   if (data && state.s3.credentials) {
     state.s3.credentials.accessKeyId = data;
@@ -66,7 +83,10 @@ const accessKeyId = (json: StorageUpdate, state: StorageState): StorageState => 
   return state;
 };
 
-const secretAccessKey = (json: StorageUpdate, state: StorageState): StorageState => {
+const secretAccessKey = (
+  json: StorageUpdate,
+  state: StorageState
+): StorageState => {
   const data = _.get(json, 'setSecretAccessKey', false);
   if (data && state.s3.credentials) {
     state.s3.credentials.secretAccessKey = data;

--- a/ui/src/state/storage/reducer.ts
+++ b/ui/src/state/storage/reducer.ts
@@ -102,6 +102,28 @@ const region = (json: StorageUpdate, state: StorageState): StorageState => {
   return state;
 };
 
+const presignedUrl = (
+  json: StorageUpdate,
+  state: StorageState
+): StorageState => {
+  const data = _.get(json, 'setPresignedUrl', false);
+  if (data && state.s3.configuration) {
+    state.s3.configuration.presignedUrl = data;
+  }
+  return state;
+};
+
+const toggleService = (
+  json: StorageUpdate,
+  state: StorageState
+): StorageState => {
+  const data = _.get(json, 'toggleService', false);
+  if (data && state.s3.configuration) {
+    state.s3.configuration.service = data;
+  }
+  return state;
+};
+
 const reduce = [
   credentials,
   configuration,
@@ -112,6 +134,8 @@ const reduce = [
   accessKeyId,
   secretAccessKey,
   region,
+  presignedUrl,
+  toggleService,
 ];
 
 export default reduce;

--- a/ui/src/state/storage/storage.ts
+++ b/ui/src/state/storage/storage.ts
@@ -20,6 +20,7 @@ export const useStorage = createState<BaseStorageState>(
   () => ({
     loaded: false,
     hasCredentials: false,
+    backend: "tlon-hosting",
     s3: {
       configuration: {
         buckets: new Set(),
@@ -27,6 +28,10 @@ export const useStorage = createState<BaseStorageState>(
         region: '',
       },
       credentials: null,
+    },
+    tlonHosting: {
+      endpoint: 'http://localhost:8888',
+      token: 'token',
     },
   }),
   {},

--- a/ui/src/state/storage/storage.ts
+++ b/ui/src/state/storage/storage.ts
@@ -20,18 +20,15 @@ export const useStorage = createState<BaseStorageState>(
   () => ({
     loaded: false,
     hasCredentials: false,
-    backend: "tlon-hosting",
     s3: {
       configuration: {
         buckets: new Set(),
         currentBucket: '',
         region: '',
+        presignedUrl: '',
+        service: 'credentials',
       },
       credentials: null,
-    },
-    tlonHosting: {
-      endpoint: 'http://localhost:8888',
-      token: 'token',
     },
   }),
   {},

--- a/ui/src/state/storage/upload.ts
+++ b/ui/src/state/storage/upload.ts
@@ -6,7 +6,7 @@ import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { getImageSize } from 'react-image-size';
 import { useCallback, useEffect, useState } from 'react';
-import { FileStore, Status, StorageCredentials, Uploader } from '@/gear';
+import { FileStore, Status, StorageCredentialsS3, Uploader } from '@/gear';
 import { useStorage } from './storage';
 import { StorageState } from './reducer';
 
@@ -25,7 +25,7 @@ function imageSize(url: string) {
 export const useFileStore = create<FileStore>((set, get) => ({
   client: null,
   uploaders: {},
-  createClient: (credentials: StorageCredentials, region: string) => {
+  createClient: (credentials: StorageCredentialsS3, region: string) => {
     const endpoint = new URL(prefixEndpoint(credentials.endpoint));
     const client = new S3Client({
       endpoint: {

--- a/ui/src/state/storage/upload.ts
+++ b/ui/src/state/storage/upload.ts
@@ -10,7 +10,7 @@ import { FileStore, Status, StorageCredentialsS3, Uploader } from '@/gear';
 import { useStorage } from './storage';
 import { StorageState } from './reducer';
 
-export function prefixEndpoint(endpoint: string) {
+function prefixEndpoint(endpoint: string) {
   return endpoint.match(/https?:\/\//) ? endpoint : `https://${endpoint}`;
 }
 
@@ -173,7 +173,7 @@ const emptyUploader = (key: string, bucket: string): Uploader => ({
   },
 });
 
-export function useClient() {
+function useClient() {
   const {
     s3: { credentials, configuration },
   } = useStorage();


### PR DESCRIPTION
From @arthyn: This fixes LAND-999 by adding new state to the %storage backend and allows hosting users to customize whether they want to use Tlon provided presigned URLs or their own custom credentials for direct S3 uploads.

<img width="497" alt="image" src="https://github.com/tloncorp/landscape/assets/5466421/9b463e89-4982-4aaa-bc15-b929647fa767">

<img width="561" alt="image" src="https://github.com/tloncorp/landscape/assets/5466421/6ff1a8e5-4c60-4faa-81fe-ade214ea5fca">

Similar changes are being pulled into the Tlon app here: https://github.com/tloncorp/landscape-apps/pull/2906