### PR TITLE
vere: fix vere version check for 412k

### DIFF
--- a/ui/src/state/vere.ts
+++ b/ui/src/state/vere.ts
@@ -46,10 +46,10 @@ const fetchRuntimeVersion = () => {
       useVereState.setState((state) => {
         if (typeof data === 'object' && data !== null) {
           const vereData = data as Vere;
-          const vereVersion = vereData.cur.rev.split('/vere/live/~.')[1];
+          const vereVersion = vereData.cur.rev.split('/')[2].substr(2);
           const latestVereVersion =
             vereData.next !== undefined
-              ? vereData.next.rev.split('/vere/live/~.')[1]
+              ? vereData.next.rev.split('/')[2].substr(2)
               : vereVersion;
           const isLatest =
             vereVersion === latestVereVersion || vereData.next === undefined;

--- a/ui/src/state/vere.ts
+++ b/ui/src/state/vere.ts
@@ -46,10 +46,10 @@ const fetchRuntimeVersion = () => {
       useVereState.setState((state) => {
         if (typeof data === 'object' && data !== null) {
           const vereData = data as Vere;
-          const vereVersion = vereData.cur.rev.split('/')[2].substr(2);
+          const vereVersion = vereData.cur.rev.split('/')[3].substr(2);
           const latestVereVersion =
             vereData.next !== undefined
-              ? vereData.next.rev.split('/')[2].substr(2)
+              ? vereData.next.rev.split('/')[2].substr(3)
               : vereVersion;
           const isLatest =
             vereVersion === latestVereVersion || vereData.next === undefined;


### PR DESCRIPTION
The path format is now different because it includes the pace of the runtime (edge, soon or live). See https://github.com/urbit/vere/pull/473.