### PR TITLE
growl: don't fumble the activity logging consent

### DIFF
--- a/desk/app/bark.hoon
+++ b/desk/app/bark.hoon
@@ -76,7 +76,13 @@
       %bark-remove-recipient
     =+  !<(=ship vase)
     ?>  =(src.bowl ship)
-    `this(recipients (~(del in recipients) ship))
+    :_  this(recipients (~(del in recipients) ship))
+    :_  ~
+    :*  %pass  /save-summary/(scot %p src.bowl)/(scot %da now.bowl)
+        %arvo  %k  %fard
+        %landscape  %save-summary  %noun
+        !>(`[tlon.api mailchimp.api src.bowl %wipe ~])
+    ==
     ::
       %bark-generate-summaries
     ?>  =(src.bowl our.bowl)
@@ -107,7 +113,7 @@
           ==  ==
       vase
     ?~  result
-      `this(recipients (~(del in recipients) src.bowl))
+      $(mark %bark-remove-recipient, vase !>(src.bowl))
     ::TODO  maybe drop the result (or re-request) if the timestamp is too old?
     :_  this
     :~  :*  %pass  /save-summary/(scot %p src.bowl)/(scot %da requested.u.result)

--- a/desk/app/growl.hoon
+++ b/desk/app/growl.hoon
@@ -3,15 +3,12 @@
 ::
 |%
 +$  card  card:agent:gall
-+$  versioned-state
-  $%  state-0
-  ==
-+$  state-0  [%0 enabled=_| bark-host=_~rilfet-palsum]
++$  state-1  [%1 enabled=_| bark-host=_~rilfet-palsum]
 --
 ::
 ::  This agent should eventually go into landscape
 ::
-=|  state-0
+=|  state-1
 =*  state  -
 %-  agent:dbug
 %+  verb  |
@@ -41,6 +38,26 @@
       (~(gut by desk.data) %groups ~)
     'logActivity'
   [%b |]
+::
+++  on-save  !>(state)
+++  on-load
+  |=  old-state=vase
+  |^  ^-  (quip card _this)
+      =+  !<(old=versioned-state old-state)
+      ?-  -.old
+          %0
+        =^  caz  this  on-init  ::  %0 dropped the ball, re-initialize
+        :_  this
+        :_  caz
+        [%pass /settings %agent [our.bowl %settings] %leave ~]
+      ::
+          %1
+        [~ this(state old)]
+      ==
+  ::
+  +$  versioned-state  $%(state-0 state-1)
+  +$  state-0  [%0 enabled=_| bark-host=_~rilfet-palsum]
+  --
 ::
 ++  on-poke
   |=  [=mark =vase]
@@ -91,17 +108,19 @@
       %fact
     ?.  =(%settings-event p.cage.sign)  (on-agent:def wire sign)
     =+  !<(=event:settings q.cage.sign)
-    =/  new=?
-      =;  =val:settings
-        ?:(?=(%b -.val) p.val |)
-      ?+  event  b+|
-        [%put-bucket %groups %groups *]  (~(gut by bucket.event) 'logActivity' b+|)
-        [%del-bucket %groups %groups]    b+|
-        [%put-entry %groups %groups %'logActivity' *]  val.event
-        [%del-entry %groups %groups %'logActivity']    b+|
+    =/  new=(unit ?)
+      =;  val=(unit val:settings)
+        ?~  val  ~
+        `?:(?=(%b -.u.val) p.u.val |)
+      ?+  event  ~
+        [%put-bucket %groups %groups *]  `(~(gut by bucket.event) 'logActivity' b+|)
+        [%del-bucket %groups %groups]    `b+|
+        [%put-entry %groups %groups %'logActivity' *]  `val.event
+        [%del-entry %groups %groups %'logActivity']    `b+|
       ==
-    ?:  =(new enabled)  [~ this]
-    (on-poke ?:(new %enable %disable) !>(~))
+    ?~  new  [~ this]
+    ?:  =(u.new enabled)  [~ this]
+    (on-poke ?:(u.new %enable %disable) !>(~))
   ==
 ::
 ++  on-watch  on-watch:def
@@ -111,15 +130,6 @@
 ++  on-leave
   |=  =path
   `this
-++  on-save  !>(state)
-++  on-load
-  |=  old-state=vase
-  ^-  (quip card _this)
-  =/  old  !<(versioned-state old-state)
-  ?-  -.old
-      %0
-    `this(state old)
-  ==
 ++  on-arvo  on-arvo:def
 ++  on-peek  on-peek:def
 --

--- a/desk/ted/mailchimp/update-merge-fields.hoon
+++ b/desk/ted/mailchimp/update-merge-fields.hoon
@@ -5,7 +5,8 @@
 ::
 ::  > -bark!mailchimp-update-merge-fields 'apikey' 'list-id' 'sampel@example.com' fields
 ::  where fields is a (map cord json)
-::  and the list-id is most easily discovered through the /lists api
+::  and the list-id is most easily discovered through the /lists api:
+::  curl -X GET 'https://us14.api.mailchimp.com/3.0/lists?count=99&offset=0' --user "anystring:${apikey}"
 ::
 /-  spider
 /+  *strandio
@@ -26,7 +27,7 @@
   ::
     ^=  body
     %-  some
-    %-  as-octt:mimes:html
+    %-  as-octs:mimes:html
     %-  en:json:html
     %-  pairs:enjs:format
     ['merge_fields' o+vars]~

--- a/desk/ted/save-summary.hoon
+++ b/desk/ted/save-summary.hoon
@@ -63,5 +63,5 @@
 ::
 =/  [%khan %arow %.y %noun vs=vase]  simp
 =+  !<([gud=? msg=@t] vs)
-?.  gud  ~|(msg !!)
+?.  gud  ~|([ship=ship.args mail=u.mail msg] !!)
 (pure:m !>(msg))

--- a/desk/ted/save-summary.hoon
+++ b/desk/ted/save-summary.hoon
@@ -18,6 +18,7 @@
     ::
       $=  summary
       $%  [%life [sen=@ud rec=@ud gro=@t] [dms=@ud etc=@ud group=@t chat=@t]]
+          [%wipe ~]
       ==
   ==
 =/  args  !<([~ arg-mold] arg)
@@ -45,6 +46,9 @@
       =;  vars=(map @t json)
         !>(`[mailchimp.args u.mail vars])
       %-  ~(gas by *(map @t json))
+      =?  summary.args  ?=(%wipe -.summary.args)
+        [%life [0 0 ''] [0 0 '' '']]
+      ?>  ?=(%life -.summary.args)
       =,  summary.args
       :~  ['MSGS_SENT' (numb:enjs:format sen)]
           ['MSGS_RECD' (numb:enjs:format rec)]


### PR DESCRIPTION
Previous logic for reading `%settings-event` facts was a little too eager
in declaring explicit non-consent. It would also set the flag to false
in cases where we received updates not matching what we were looking
for.

Now, it's not entirely certain that this was a problem, but we did
observe "disabled growl" on ships that had the setting toggle on the
frontend set to true, and this seemed like the only viable cause of
that.

We also update +on-load to re-set the flag from the current settings
value, to correct any lingering mismatching states.

We may want to make an additional, largely unrelated change to bark that should go out alongside this, but discussion pending. See also COMMS-242.