### PR TITLE
system preferences: fix vere version parsing

### DIFF
--- a/ui/src/preferences/SystemPreferences.tsx
+++ b/ui/src/preferences/SystemPreferences.tsx
@@ -77,7 +77,7 @@ export const SystemPreferences = () => {
   const { systemBlocked } = useSystemUpdate();
   const charges = useCharges();
   const filteredCharges = Object.values(charges).filter(
-    (charge) => charge.desk !== 'landscape' && charge.desk !== 'garden'
+    (charge) => charge.desk !== 'garden'
   );
   const isMobile = useMedia('(max-width: 639px)');
 

--- a/ui/src/state/vere.ts
+++ b/ui/src/state/vere.ts
@@ -22,6 +22,20 @@ interface VereState {
   nock?: number;
 }
 
+function parseVersion(versionPath: string | undefined) {
+  if (versionPath === undefined) {
+    return null;
+  }
+
+  const pattern = /~\.(\d+\.\d+)/gi;
+  const match = pattern.exec(versionPath);
+  if (!match) {
+    return null;
+  }
+
+  return match[1];
+}
+
 const useVereState = create<Vere>((set, get) => ({
   cur: {
     rev: '',
@@ -46,10 +60,10 @@ const fetchRuntimeVersion = () => {
       useVereState.setState((state) => {
         if (typeof data === 'object' && data !== null) {
           const vereData = data as Vere;
-          const vereVersion = vereData.cur.rev.split('/')[3].substr(2);
+          const vereVersion = parseVersion(vereData.cur.rev);
           const latestVereVersion =
             vereData.next !== undefined
-              ? vereData.next.rev.split('/')[2].substr(3)
+              ? parseVersion(vereData.next.rev)
               : vereVersion;
           const isLatest =
             vereVersion === latestVereVersion || vereData.next === undefined;


### PR DESCRIPTION
This fixes LAND-1027 by making sure we parse the version strings the same way, and uses a more reliable method. Also unfilters Landscape from the sidebar so people can see their OTA source and change it.