### PR TITLE
storage: hardcode url to mimic groups

### DIFF
--- a/ui/src/env.d.ts
+++ b/ui/src/env.d.ts
@@ -1,6 +1,8 @@
-interface ImportMetaEnv extends Readonly<Record<string, string | boolean | undefined>> {
+interface ImportMetaEnv
+  extends Readonly<Record<string, string | boolean | undefined>> {
   readonly VITE_LAST_WIPE: string;
   readonly VITE_STORAGE_VERSION: string;
+  readonly VITE_SHIP_URL: string;
 }
 
 interface ImportMeta {

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -15,8 +15,21 @@ import { useCallback, useState } from 'react';
 
 export const useMockData = import.meta.env.MODE === 'mock';
 
+export const isStagingHosted =
+  import.meta.env.DEV &&
+  (import.meta.env.VITE_SHIP_URL.endsWith('.test.tlon.systems') ||
+    window.location.hostname.endsWith('.test.tlon.systems'));
 export const isHosted =
-  import.meta.env.DEV || window.location.hostname.endsWith('.tlon.network');
+  isStagingHosted ||
+  (import.meta.env.DEV &&
+    (import.meta.env.VITE_SHIP_URL.endsWith('.tlon.network') ||
+      window.location.hostname.endsWith('.tlon.network')));
+
+export const hostingUploadURL = isStagingHosted
+  ? 'https://memex.test.tlon.systems'
+  : isHosted
+  ? 'https://memex.tlon.network'
+  : '';
 
 export async function fakeRequest<T>(data: T, time = 300): Promise<T> {
   return new Promise((resolve) => {

--- a/ui/src/state/storage/reducer.ts
+++ b/ui/src/state/storage/reducer.ts
@@ -3,6 +3,7 @@ import { StorageUpdate } from '@/gear';
 import _ from 'lodash';
 import { BaseStorageState } from '@/gear';
 import { BaseState } from '../base';
+import { hostingUploadURL } from '@/logic/utils';
 
 export type StorageState = BaseStorageState & BaseState<BaseStorageState>;
 
@@ -27,8 +28,10 @@ const configuration = (
       buckets: new Set(data.buckets),
       currentBucket: data.currentBucket,
       region: data.region,
-      presignedUrl: data.presignedUrl,
-      service: data.service,
+      // if landscape is not up to date we need to default these so the
+      // client init logic still works
+      presignedUrl: data.presignedUrl || hostingUploadURL,
+      service: data.service || 'credentials',
     };
   }
   return state;

--- a/ui/src/state/storage/storage.ts
+++ b/ui/src/state/storage/storage.ts
@@ -26,7 +26,7 @@ export const useStorage = createState<BaseStorageState>(
         buckets: new Set(),
         currentBucket: '',
         region: '',
-        presignedUrl: '',
+        presignedUrl: hostingUploadURL,
         service: 'credentials',
       },
       credentials: null,
@@ -70,5 +70,3 @@ export const useStorage = createState<BaseStorageState>(
       ),
   ]
 );
-
-window.useStorage = useStorage;

--- a/ui/src/state/storage/storage.ts
+++ b/ui/src/state/storage/storage.ts
@@ -8,6 +8,7 @@ import {
   reduceStateN,
   BaseState,
 } from '../base';
+import { hostingUploadURL, isHosted } from '@/logic/utils';
 
 enableMapSet();
 
@@ -44,9 +45,30 @@ export const useStorage = createState<BaseStorageState>(
           }
           numLoads += 1;
           if (numLoads === 2) {
-            set({ loaded: true });
+            const {
+              s3: { credentials, configuration },
+            } = get();
+
+            if (!credentials?.endpoint && isHosted) {
+              set({
+                loaded: true,
+                s3: {
+                  credentials,
+                  configuration: {
+                    ...configuration,
+                    presignedUrl:
+                      configuration.presignedUrl || hostingUploadURL,
+                    service: 'presigned-url',
+                  },
+                },
+              });
+            } else {
+              set({ loaded: true });
+            }
           }
         }
       ),
   ]
 );
+
+window.useStorage = useStorage;


### PR DESCRIPTION
This matches https://github.com/tloncorp/landscape-apps/pull/2973 so that hosted ships see their toggle in the correct state even if they don't actually have a presigned URL set in their storage state.