### PR TITLE
docket: fix URL encoding handling

### DIFF
--- a/desk/app/docket.hoon
+++ b/desk/app/docket.hoon
@@ -679,11 +679,8 @@
   ::
   ++  fip
     |=  fil=@t
-    =/  fil  (trip fil)
-    =^  ext  fil  (split-at (flop fil) '.')
-    =/  ext  (crip (flop ext))
-    =.  fil  (flop fil)
-    =-  (snoc - ext)
+    =/  [fil=tape ext=tape]  (split-at (trip fil) '.')
+    =-  (snoc - (crip ext))
     %+  turn
       (scan fil (most fas (star ;~(less fas next))))
     |=  t=^tape

--- a/desk/app/docket.hoon
+++ b/desk/app/docket.hoon
@@ -703,6 +703,7 @@
     ?:  =(suffix /desk/js)
       %-  inline-js-response
       (rap 3 'window.desk = "' u.des '";' ~)
+    =.  suffix  (turn suffix |=(s=@t (crip (en-urlt:html (trip s)))))
     =/  requested
       ?:  (~(has by glob) suffix)  suffix
       /index/html

--- a/desk/app/docket.hoon
+++ b/desk/app/docket.hoon
@@ -656,28 +656,40 @@
     ?~  file            [glob 'file without filename' err]
     ?~  type            [glob (cat 3 'file without type: ' u.file) err]
     ?^  code            [glob (cat 3 'strange encoding: ' u.code) err]
-    =/  filp            (rush u.file fip)
-    ?~  filp            [glob (cat 3 'strange filename: ' u.file) err]
+    =/  filp            (fip u.file)
     ::  ignore metadata files and other "junk"
     ::TODO  consider expanding coverage
     ::
-    ?:  =('.DS_Store' (rear `path`u.filp))
+    ?:  =('.DS_Store' (rear `path`filp))
       [glob err]
     ::  make sure to exclude the top-level dir from the path
     ::
     :_  err
-    %+  ~(put by glob)  (slag 1 `path`u.filp)
+    %+  ~(put by glob)  (slag 1 `path`filp)
     [u.type (as-octs:mimes:html body)]
   ::
+  ++  split-at
+    =|  fst=tape
+    |=  [=tape char=@tD]
+    ^+  [fst fst]
+    ?~  tape  [fst tape]
+    ?:  =(i.tape char)
+      [fst t.tape]
+    $(tape t.tape, fst (snoc fst i.tape))
+  ::
   ++  fip
-    =,  de-purl:html
-    ;:  cook
-      |=(pork (weld q (drop p)))
-      deft
-      |=(a=cord (rash a (more fas smeg))) 
-      crip 
-      (star ;~(pose (cold '%20' (just ' ')) next))
-    ==
+    |=  fil=@t
+    =/  fil  (trip fil)
+    =^  ext  fil  (split-at (flop fil) '.')
+    =/  ext  (crip (flop ext))
+    =.  fil  (flop fil)
+    =-  (snoc - ext)
+    %+  turn
+      (scan fil (most fas (star ;~(less fas next))))
+    |=  t=^tape
+    %-  crip
+    (en-urlt:html t)
+  ::
   ::
   ++  inline-js-response
     |=  js=cord


### PR DESCRIPTION
Handles URL encoding special characters on the docket upload side, and when retrieving files from the glob.

cc: @arthyn @Fang- 

Expedited review/deploy would be helpful, this is blocking third party integrations