### PR TITLE
patch many minor issues with `vitals/connection-check.hoon` thread

### DIFF
--- a/desk/app/vitals.hoon
+++ b/desk/app/vitals.hoon
@@ -160,10 +160,7 @@
   ::
       %ship
     =+  !<(=ship vase)
-    ?<  =(our ship)
-    ?<  =(~ (find ~[our] (saxo:title our now ship)))
-    ?.  ?=([%live *] (scry-qos:lib our now ship))
-      !!
+    ?>  ?=([%live *] (scry-qos:lib our now ship))
     cor
   ==
 ++  watch
@@ -187,14 +184,12 @@
   ?+  path  [~ ~]
   ::
       [%x %sponsor ~]
-    ?<  ?=(%czar (clan:title our))
     %-  some
     %-  some
     :-  %vitals-qos
     !>  (scry-qos:lib our now (sein:title our now our))
   ::
       [%x %galaxy ~]
-    ?<  ?=(%czar (clan:title our))
     %-  some
     %-  some
     :-  %vitals-qos

--- a/desk/app/vitals.hoon
+++ b/desk/app/vitals.hoon
@@ -138,7 +138,7 @@
           %landscape
           %vitals-connection-check
           %noun
-          !>(ship)
+          !>((some ship))
       ==
     ?:  ?=(%pending -.status.u.stat)
       cor
@@ -153,7 +153,7 @@
         %landscape
         %vitals-connection-check
         %noun
-        !>(ship)
+        !>((some ship))
     ==
   ::
   ::  public pokes

--- a/desk/lib/vitals.hoon
+++ b/desk/lib/vitals.hoon
@@ -14,20 +14,13 @@
   ::  a ship is not guaranteed by %ames to know itself, so we fake it
   ?:  =(ship peer)
     [%live time]
-  ::  .^(* %ax /=//=/peers/[peer]) crashes if the peer is unknown, so we
+  ::  .^(* /ax/=//=/peers/[peer]) crashes if the peer is unknown, so we
   ::  check the source map beforehand and fake an %unborn if we can see
   ::  a crash coming
-  =/  peers  .^((map ^ship ?(%alien %known)) ~[%ax %$ %peers])
+  =/  ames-peers=path  /ax/(scot %p ship)//(scot %da time)/peers
+  =/  peers  .^((map ^ship ?(%alien %known)) ames-peers)
   ?.  (~(has by peers) peer)
     [%unborn time]
-  %-  simplify-qos
-  .^  ship-state:ames
-      %ax
-      (scot %p ship)
-      %$
-      (scot %da time)
-      %peers
-      (scot %p peer)
-      ~
-  ==
+  =/  pqos  .^(ship-state:ames (snoc ames-peers (scot %p peer)))
+  (simplify-qos pqos)
 --

--- a/desk/lib/vitals.hoon
+++ b/desk/lib/vitals.hoon
@@ -11,6 +11,15 @@
 ++  scry-qos
   |=  [=ship =time peer=ship]
   ^-  qos:ames
+  ::  a ship is not guaranteed by %ames to know itself, so we fake it
+  ?:  =(ship peer)
+    [%live time]
+  ::  .^(* %ax /=//=/peers/[peer]) crashes if the peer is unknown, so we
+  ::  check the source map beforehand and fake an %unborn if we can see
+  ::  a crash coming
+  =/  peers  .^((map ^ship ?(%alien %known)) ~[%ax %$ %peers])
+  ?.  (~(has by peers) peer)
+    [%unborn time]
   %-  simplify-qos
   .^  ship-state:ames
       %ax

--- a/desk/ted/vitals/connection-check.hoon
+++ b/desk/ted/vitals/connection-check.hoon
@@ -12,9 +12,9 @@
 ^-  form:m
 =+  !<([~ target=ship] arg)
 ;<  our=@p  bind:m  get-our:io
+;<  now=@da  bind:m  get-time:io
 |^
   ::  early exit; check if we have live path to target
-  ;<  now=@da  bind:m  get-time:io
   ;<  tqos=qos:ames  bind:m  (get-qos target)
   ?:  ?&  ?=(%live -.tqos)
           (gth last-contact.tqos (sub now info-timeout:vitals))
@@ -33,13 +33,7 @@
   ::  set pending to %trying-local
   ;<  ~  bind:m  (update-status [%trying-local ~])
   ::  check if we can contact our own galaxy
-  ;<    gqos=qos:ames
-      bind:m
-    =/  mm  (strand ,qos:ames)
-    ^-  form:mm
-    ?:  ?=(%czar (clan:title our))
-      (pure:mm [%live *@da])
-    (scry:io qos:ames ~[%gx %vitals %galaxy %vitals-qos])
+  ;<  gqos=qos:ames  bind:m  (scry:io qos:ames ~[%gx %vitals %galaxy %vitals-qos])
   ?.  ?=(%live -.gqos)
     (post-result [%no-our-galaxy last-contact.gqos])
   ::  set pending to %trying-target
@@ -102,21 +96,23 @@
   |=  =pending:vitals
   =/  m  (strand ,~)
   ^-  form:m
-  ;<  now=@da  bind:m  get-time:io
   %+  poke-our:io
     %vitals
   :-  %update-status
   !>
   ^-  update:vitals
   [target now %pending pending]
+::  thread version of +scry-qos in /=landscape=/lib/vitals/hoon
 ++  get-qos
   |=  peer=ship
   =/  m  (strand ,qos:ames)
   ^-  form:m
+  ?:  =(our peer)
+    (pure:m [%live now])
   ;<  peers=(map ship ?(%alien %known))  bind:m
     (scry:io (map ship ?(%alien %known)) ~[%ax %$ %peers])
   ?.  (~(has by peers) peer)
-    (pure:m [%dead *@da])
+    (pure:m [%unborn now])
   ;<  state=ship-state:ames  bind:m
     (scry:io ship-state:ames ~[%ax %$ %peers (scot %p peer)])
   (pure:m (simplify-qos:lib-vitals state))

--- a/desk/ted/vitals/connection-check.hoon
+++ b/desk/ted/vitals/connection-check.hoon
@@ -10,7 +10,7 @@
 |=  arg=vase
 =/  m  (strand ,vase)
 ^-  form:m
-=+  !<(target=ship arg)
+=+  !<([~ target=ship] arg)
 ;<  our=@p  bind:m  get-our:io
 |^
   ::  early exit; check if we have live path to target
@@ -33,7 +33,13 @@
   ::  set pending to %trying-local
   ;<  ~  bind:m  (update-status [%trying-local ~])
   ::  check if we can contact our own galaxy
-  ;<  gqos=qos:ames  bind:m  (scry:io qos:ames ~[%gx %vitals %galaxy %vitals-qos])
+  ;<    gqos=qos:ames
+      bind:m
+    =/  mm  (strand ,qos:ames)
+    ^-  form:mm
+    ?:  ?=(%czar (clan:title our))
+      (pure:mm [%live *@da])
+    (scry:io qos:ames ~[%gx %vitals %galaxy %vitals-qos])
   ?.  ?=(%live -.gqos)
     (post-result [%no-our-galaxy last-contact.gqos])
   ::  set pending to %trying-target
@@ -104,12 +110,15 @@
   ^-  update:vitals
   [target now %pending pending]
 ++  get-qos
-  |=  =ship
+  |=  peer=ship
   =/  m  (strand ,qos:ames)
   ^-  form:m
-  ;<    state=ship-state:ames
-      bind:m
-    (scry:io ship-state:ames ~[%ax %$ %peers (scot %p ship)])
+  ;<  peers=(map ship ?(%alien %known))  bind:m
+    (scry:io (map ship ?(%alien %known)) ~[%ax %$ %peers])
+  ?.  (~(has by peers) peer)
+    (pure:m [%dead *@da])
+  ;<  state=ship-state:ames  bind:m
+    (scry:io ship-state:ames ~[%ax %$ %peers (scot %p peer)])
   (pure:m (simplify-qos:lib-vitals state))
 ++  galaxy-down
   |=  galaxy=ship

--- a/desk/ted/vitals/connection-check.hoon
+++ b/desk/ted/vitals/connection-check.hoon
@@ -12,10 +12,10 @@
 ^-  form:m
 =+  !<([~ target=ship] arg)
 ;<  our=@p  bind:m  get-our:io
-;<  now=@da  bind:m  get-time:io
 |^
   ::  early exit; check if we have live path to target
   ;<  tqos=qos:ames  bind:m  (get-qos target)
+  ;<  now=@da  bind:m  get-time:io
   ?:  ?&  ?=(%live -.tqos)
           (gth last-contact.tqos (sub now info-timeout:vitals))
       ==
@@ -96,6 +96,7 @@
   |=  =pending:vitals
   =/  m  (strand ,~)
   ^-  form:m
+  ;<  now=@da  bind:m  get-time:io
   %+  poke-our:io
     %vitals
   :-  %update-status
@@ -107,6 +108,7 @@
   |=  peer=ship
   =/  m  (strand ,qos:ames)
   ^-  form:m
+  ;<  now=@da  bind:m  get-time:io
   ?:  =(our peer)
     (pure:m [%live now])
   ;<  peers=(map ship ?(%alien %known))  bind:m


### PR DESCRIPTION
Includes the following fixes (which allow this thread and the associated app to be used trivially on fake ships/networks):

- skip sponsor checks for galaxies (avoids a crash in /app/vitals/hoon)
- mark peers unknown to %ames as %dead (avoids [a crash in /ax/peers/...](https://docs.urbit.org/system/kernel/ames/reference/scry#peers[ship]))
- change thread input from `@p` to `(unit @p)` (allow [calling from dojo](https://docs.urbit.org/userspace/threads/tutorials/basics/fundamentals#a-trivial-thread))

Only tested locally with the following manual test algorithm:

1. With `~zod` and `~nec` live on a local network (with no prior communications between them), run the following on `~zod`:
    ```
    :vitals &run-check ~nec
    ```
 2. Wait a few seconds and then run the following on `~zod` and verify a `[%complete %yes ~]` result:
    ```
    =v -build-file /=landscape=/sur/vitals/hoon
    .^(result:v %gx /=vitals=/ship/~nec/noun)
    ```
 3. Repeat the above on `~nec` while substituting `~zod` as the destination ship, and verify a `[%complete %yes ~]` result:
    ```
    :vitals &run-check ~zod
    ::  wait a few seconds
    =v -build-file /=landscape=/sur/vitals/hoon
    .^(result:v %gx /=vitals=/ship/~zod/noun)
    ```
 4. Run the following from `~zod` and verify a `[%yes ~]` result:
     ```
    -landscape!vitals-connection-check ~nec
     ```
 5. Finally, run the following from `~zod` and verify a `[%complete %no-their-galaxy ...]` result:
     ```
    :vitals &run-check ~bud
    ::  wait a few seconds
    .^(result:v %gx /=vitals=/ship/~bud/noun)
     ```