### PR TITLE
contacts: turn off verb by default

### DIFF
--- a/desk/app/contacts.hoon
+++ b/desk/app/contacts.hoon
@@ -18,7 +18,7 @@
 --
 ::
 %-  agent:dbug
-%+  verb  &
+%+  verb  |
 ^-  agent:gall
 =|  state-0
 =*  state  -


### PR DESCRIPTION
Does what it says on the tin. We generally shouldn't have verb on by default, it adds to the (already quite bad) console output clutter.