### PR TITLE
treaty: subscribe for treaties to prevent race condition

### DIFF
--- a/desk/app/treaty.hoon
+++ b/desk/app/treaty.hoon
@@ -112,6 +112,17 @@
     ::      present in the treaties map
     (fact-init:io (treaty-update:cg:cc %ini treaties))^~
     ::
+      [%treaties @ ~]
+    :_  this
+    =/  =ship  (slav %p i.t.path)
+    =/  alliance  (~(get ju allies) ship)
+    =/  allied
+      %-  ~(gas by *(map [^ship desk] treaty))
+      %+  skim  ~(tap by treaties)
+      |=  [ref=[^ship desk] =treaty]
+      (~(has in alliance) ref)
+    (fact-init:io (treaty-update:cg:ca:cc %ini allied))^~
+    ::
       [%alliance ~]
     :_  this
     (fact-init:io (alliance-update:cg:cc %ini entente))^~
@@ -308,12 +319,14 @@
   ++  gone
     ^-  (list card)
     :~  (fact:io (treaty-update:cg %del ship desk) /treaties ~)
+        (fact:io (treaty-update:cg %del ship desk) /treaties/[(scot %p ship)] ~)
         (kick-only:io our.bowl path ~)
     ==
   ++  give
     ^-  (list card)
     =/  t=treaty  (~(got by treaties) ship desk)
     :~  (fact:io (treaty-update:cg %add t) /treaties ~)
+        (fact:io (treaty-update:cg %add t) /treaties/[(scot %p ship)] ~)
         (fact:io (treaty:cg t) path ~)
     ==
   --

--- a/desk/app/treaty.hoon
+++ b/desk/app/treaty.hoon
@@ -4,6 +4,7 @@
 ++  default-ally  ~dister-dozzod-dozzod
 ::
 +$  card  card:agent:gall
++$  state-1  [%1 state-0]
 +$  state-0
   $:  treaties=(map [=ship =desk] treaty)
       sovereign=(map desk treaty)
@@ -15,7 +16,7 @@
 ^-  agent:gall
 %+  verb  |
 %-  agent:dbug
-=|  state-0
+=|  state-1
 =*  state  -
 =<
 |_  =bowl:gall
@@ -30,8 +31,19 @@
 ++  on-save  !>(state)
 ++  on-load
   |=  =vase
+  ?:  =(%1 -.q.vase)
+    =+  !<(old=state-1 vase)
+    `this(state old)
   =+  !<(old=state-0 vase)
-  `this(state old)
+  :_  this(state [%1 old])
+  %-  zing
+  ^-  (list (list card))
+  %+  turn  ~(tap by allies.old)
+  |=  [=ship s=(set *)]
+  ^-  (list card)
+  =*  al  ~(. al:cc ship)
+  ?^  s  ~
+  ~[leave:al watch:al]
 ::
 ++  on-poke
   |=  [=mark =vase]
@@ -59,7 +71,7 @@
     ?<  =(ship our.bowl)
     =*  al   ~(. al:cc ship.update)
     ?-  -.update
-      %add  [~[watch:al] this(allies (~(put by allies) ship *alliance))]
+      %add  [~[leave:al watch:al] this(allies (~(put by allies) ship *alliance))]
       %del  [~[leave:al] this(allies (~(del by allies) ship))]
     ==
   ::

--- a/desk/app/treaty.hoon
+++ b/desk/app/treaty.hoon
@@ -330,8 +330,7 @@
   ++  leave  (leave:pass dock)
   ++  gone
     ^-  (list card)
-    :~  (fact:io (treaty-update:cg %del ship desk) /treaties ~)
-        (fact:io (treaty-update:cg %del ship desk) /treaties/[(scot %p ship)] ~)
+    :~  (fact:io (treaty-update:cg %del ship desk) /treaties /treaties/[(scot %p ship)] ~)
         (kick-only:io our.bowl path ~)
     ==
   ++  give

--- a/ui/src/state/docket.ts
+++ b/ui/src/state/docket.ts
@@ -223,10 +223,15 @@ export function useAllyTreaties(ship: string) {
   //     [ship]
   //   )
   // );
-  const { data: treatyData, isLoading } = useReactQueryScry<TreatyUpdateIni>({
+
+  const { data: treatyData, isLoading } = useReactQuerySubscription<
+    TreatyUpdateIni,
+    TreatyUpdate
+  >({
     queryKey: ['treaty', 'treaties', ship],
     app: 'treaty',
     path: `/treaties/${ship}`,
+    scry: `/treaties/${ship}`,
     options: {
       enabled: isAllied,
     },
@@ -238,6 +243,7 @@ export function useAllyTreaties(ship: string) {
     }
     return normalizeDockets(treatyData.ini);
   }, [treatyData]);
+
   const status = getAllyTreatyStatus(
     treaties,
     isLoading,


### PR DESCRIPTION
When you search for a ship for the first time in the landscape software distribution UI it's very common to enter a scenario where the UI gets stuck on "X apps found, waiting for entries", yet the entries never show up until you refresh the page. Whether you hit this case seems to be dependent on how fast the %vitals connection check completes.

This PR fixes the issue by having the frontend subscribe to the treaty instead of scrying for it. This requires a new `/treaties/ship` subscription endpoint which is also implemented here.