### PR TITLE
Make +ally-update %add idempotent

### DIFF
--- a/desk/app/treaty.hoon
+++ b/desk/app/treaty.hoon
@@ -59,7 +59,9 @@
     ?<  =(ship our.bowl)
     =*  al   ~(. al:cc ship.update)
     ?-  -.update
-      %add  [~[watch:al] this(allies (~(put by allies) ship *alliance))]
+      %add  ?:  (~(has by allies) ship)
+              `this
+            [~[watch:al] this(allies (~(put by allies) ship *alliance))]
       %del  [~[leave:al] this(allies (~(del by allies) ship))]
     ==
   ::


### PR DESCRIPTION
Makes `%add` in `+ally-update` idempotent to prevent subscription attempts which will fail and output that error to the dojo. I haven't added a similar check to `%del` because it doesn't visibly do anything in the dojo if you try to delete an ally who doesn't exist.