### PR TITLE
summarize: work with latest dependencies

### DIFF
--- a/desk/lib/summarize.hoon
+++ b/desk/lib/summarize.hoon
@@ -37,21 +37,21 @@
       ==
   %+  roll
     %~  tap  by
-    .^  channels:c
+    .^  channels-0:c
       %gx
       (scry-path %channels /channels/channels)
     ==
-  |=  [[n=nest:c channel:c] g=(map flag:groups @ud) s=@ud r=@ud]
+  |=  [[n=nest:c channel-0:c] g=(map flag:groups @ud) s=@ud r=@ud]
   ?.  ?=(%chat kind.n)  [g s r]
-  =+  .^  paged-posts:c
+  =+  .^  paged-simple-posts:c
         %gx
         %+  scry-path  %channels
-        /chat/(scot %p ship.n)/[name.n]/posts/newer/(scot %ud (sub now range))/(scot %ud limit)/outline/channel-posts
+        /chat/(scot %p ship.n)/[name.n]/posts/newer/(scot %ud (sub now range))/(scot %ud limit)/outline/channel-simple-posts
       ==
   :-  %+  ~(put by g)  group.perm
-      (add (~(gut by g) group.perm 0) (wyt:on-posts:c posts))
-  %+  roll  (tap:on-posts:c posts)
-  |=  [[id-post:c p=(unit post:c)] s=_s r=_r]
+      (add (~(gut by g) group.perm 0) (wyt:on-simple-posts:c posts))
+  %+  roll  (tap:on-simple-posts:c posts)
+  |=  [[id-post:c p=(unit simple-post:c)] s=_s r=_r]
   ?~  p  [s r]
   ?:(=(our author.u.p) [+(s) r] [s +(r)])
 ::
@@ -115,9 +115,9 @@
   =/  [duc=@ud faz=(list [g=flag:groups n=nest:c u=@ud])]
     %+  roll
       %~  tap  by
-      .^(channels:c %gx (scry-path %channels /channels/channels))
+      .^(channels-0:c %gx (scry-path %channels /channels/channels))
     =+  .^(=unreads:c %gx (scry-path %channels /unreads/channel-unreads))
-    |=  [[n=nest:c channel:c] duc=@ud faz=(list [flag:groups nest:c @ud])]
+    |=  [[n=nest:c channel-0:c] duc=@ud faz=(list [flag:groups nest:c @ud])]
     ?.  ?=(%chat kind.n)  [duc faz]  ::  ignore non-chat channels for now
     =/  =unread:c  (~(gut by unreads) n *unread:c)
     :-  (add duc count.unread)

--- a/desk/sur/chat.hoon
+++ b/desk/sur/chat.hoon
@@ -1,12 +1,6 @@
-/-  g=groups, d=channels, dos=chat-2, uno=chat-1, zer=chat-0
+/-  g=groups, d=channels
 /-  meta
 |%
-++  old
-  |%
-  ++  zero  zer
-  ++  one   uno
-  ++  two   dos
-  --
 ::
 ::  $id: an identifier for chat messages
 +$  id     (pair ship time)
@@ -16,6 +10,11 @@
 +$  reply   [reply-seal memo:d]
 ::  $react: either an emoji identifier like :wave: or a URL for custom
 +$  react   @ta
+::  $scam: bounded search results
++$  scam
+  $:  last=(unit time)  ::  last (top-level) msg (local) id that was searched
+      =scan             ::  search results
+  ==
 ::  $scan: search results
 +$  scan  (list reference)
 ::  $blocked: a set of ships that the user has blocked
@@ -77,11 +76,12 @@
 ::
 +$  paged-writs
   $:  =writs
-      newer=(unit id)
-      older=(unit id)
+      newer=(unit time)
+      older=(unit time)
       total=@ud
   ==
 ::
++$  chat-heads  (list [=whom recency=time latest=(unit writ)])
 ::  $writs: a set of time ordered chat messages
 ::
 ++  writs
@@ -229,10 +229,12 @@
       [%club p=id:club]
   ==
 ::
++$  message-key  [=id =time]
+::
 ::  $unreads: a map of club/dm unread information
 ::
-::    unread: the last time a message was read, how many messages since,
-::    and the id of the last read message
+::    unread: the time of the most recent message, how many messages since,
+::    the id of the last read message, and the set of unread threads
 ::
 ++  unreads
   =<  unreads
@@ -242,8 +244,8 @@
   +$  unread
     $:  recency=time
         count=@ud
-        unread-id=(unit id)
-        threads=(map id id)
+        unread=(unit [message-key count=@ud])
+        threads=(map message-key [message-key count=@ud])
     ==
   +$  update
     (pair whom unread)

--- a/desk/sur/groups.hoon
+++ b/desk/sur/groups.hoon
@@ -1,9 +1,6 @@
 /-  meta, e=epic
-/-  old=group
-/-  grp=group-store
-/-  metadata-store
 |%
-++  okay  `epic:e`2
+++  okay  `epic:e`3
 ++  mar
   |%
   ++  act  `mark`(rap 3 %group-action '-' (scot %ud okay) ~)
@@ -17,7 +14,7 @@
 ::
 ::  $nest: ID for a channel, {app}/{ship}/{name}
 ::
-+$  nest  (pair dude:gall flag)
++$  nest  (pair term flag)
 ::
 ::  $sect: ID for cabal, similar to a role
 ::
@@ -145,8 +142,10 @@
       =cordon
       secret=?
       meta=data:meta
+      =flagged-content
   ==
 ::
++$  group-ui  [group saga=(unit saga:e)]
 ::  $cabal: metadata representing a $sect or role
 ::
 ++  cabal
@@ -256,6 +255,7 @@
       [%secret p=?]
       [%create p=group]
       [%del ~]
+      [%flag-content =nest =post-key src=ship]
   ==
 ::
 ::  $action: the complete set of data required to edit a group
@@ -283,6 +283,9 @@
 ::
 +$  init  [=time =group]
 ::
+::  $groups-ui: map for frontend to display groups
++$  groups-ui
+  (map flag group-ui)
 +$  groups
   (map flag group)
 +$  net-groups
@@ -303,6 +306,13 @@
   $%  [%pub p=log]
       [%sub p=time load=_| =saga:e]
   ==
+::
++$  post-key  [post=time reply=(unit time)]
+::
++$  flaggers  (set ship)
+::  $flagged-content: flagged posts and replies that need admin review
+::
++$  flagged-content  (map nest (map post-key flaggers))
 ::
 ::  $join: a join request, can elect to join all channels
 ::
@@ -352,9 +362,4 @@
   ==
 ::
 +$  gangs  (map flag gang)
-++  met     metadata-store
-::
-+$  import  [self=association:met chan=(map flag =association:met) roles=(set flag) =group:old]
-::
-+$  imports  (map flag import)
 --


### PR DESCRIPTION
Activity summarization had broken down. Some of the types have changed subtly, so we make sure to pull in the latest versions of the sur files, and update the types we use to match.

The `/sur` files here are straight copies from their tloncorp/tlon-apps counterparts. Notably the previous versions predate type cleanup and `%channels` scry api versioning, so hopefully this'll be more stable going forward.

Closes TLON-1937 upon release.

(This mostly wouldn't be necessary (and get caught much earlier) if we moved this into the groups desk, as we should. Soon...)