### PR TITLE
reel: fixing meta and url scries, token rotation, and extra metadata

### DIFF
--- a/desk/app/reel.hoon
+++ b/desk/app/reel.hoon
@@ -138,8 +138,8 @@
     =.  stable-id  (~(put by stable-id) id nonce)
     :_  this
     %+  welp
-    ?~  old-token  ~
-    ~[[%pass /undescribe %agent [civ %bait] %poke %bait-undescribe !>(u.old-token)]]
+      ?~  old-token  ~
+      ~[[%pass /undescribe %agent [civ %bait] %poke %bait-undescribe !>(u.old-token)]]
     ~[[%pass /describe %agent [civ %bait] %poke %bait-describe !>([nonce new-metadata])]]
   ::
       %reel-confirmation

--- a/desk/app/reel.hoon
+++ b/desk/app/reel.hoon
@@ -120,27 +120,26 @@
     ?>  =(our.bowl src.bowl)
     =+  !<([id=cord =metadata:reel] vase)
     =/  old-token  (~(get by stable-id) id)
-    =/  new-fields
+    =.  fields.metadata
       %-  ~(gas by fields.metadata)
       :~  ['bite-type' '2']
           ['inviter' (scot %p src.bowl)]
           ['group' id]
       ==
-    =/  new-metadata  metadata(fields new-fields)
     ::  the nonce here is a temporary identifier for the metadata
     ::  a new one will be assigned by the bait provider and returned to us
     =/  =nonce:reel  (scot %da now.bowl)
     ::  delete old metadata if we have an existing token for this id
     =?  our-metadata  ?=(^ old-token)
       (~(del by our-metadata) u.old-token)
-    =.  our-metadata  (~(put by our-metadata) nonce new-metadata)
+    =.  our-metadata  (~(put by our-metadata) nonce metadata)
     =.  open-describes  (~(put in open-describes) nonce)
     =.  stable-id  (~(put by stable-id) id nonce)
     :_  this
     %+  welp
     ?~  old-token  ~
     ~[[%pass /undescribe %agent [civ %bait] %poke %bait-undescribe !>(u.old-token)]]
-    ~[[%pass /describe %agent [civ %bait] %poke %bait-describe !>([nonce new-metadata])]]
+    ~[[%pass /describe %agent [civ %bait] %poke %bait-describe !>([nonce metadata])]]
   ::
       %reel-confirmation
     ?>  =(civ src.bowl)

--- a/desk/app/reel.hoon
+++ b/desk/app/reel.hoon
@@ -119,16 +119,27 @@
       %reel-describe
     ?>  =(our.bowl src.bowl)
     =+  !<([id=cord =metadata:reel] vase)
-    ?~  (~(has by stable-id) id)  `this
-    ::  the token here is a temporary identifier for the metadata
-    ::  a new one will be assigned by the bait provider and returned to us
-    =/  new-fields  (~(put by fields.metadata) 'bite-type' '2')
+    =/  old-token  (~(get by stable-id) id)
+    =/  new-fields
+      %-  ~(gas by fields.metadata)
+      :~  ['bite-type' '2']
+          ['inviter' (scot %p src.bowl)]
+          ['group' id]
+      ==
     =/  new-metadata  metadata(fields new-fields)
+    ::  the nonce here is a temporary identifier for the metadata
+    ::  a new one will be assigned by the bait provider and returned to us
     =/  =nonce:reel  (scot %da now.bowl)
+    ::  delete old metadata if we have an existing token for this id
+    =?  our-metadata  ?=(^ old-token)
+      (~(del by our-metadata) u.old-token)
     =.  our-metadata  (~(put by our-metadata) nonce new-metadata)
     =.  open-describes  (~(put in open-describes) nonce)
     =.  stable-id  (~(put by stable-id) id nonce)
     :_  this
+    %+  welp
+    ?~  old-token  ~
+    ~[[%pass /undescribe %agent [civ %bait] %poke %bait-undescribe !>(u.old-token)]]
     ~[[%pass /describe %agent [civ %bait] %poke %bait-describe !>([nonce new-metadata])]]
   ::
       %reel-confirmation
@@ -229,21 +240,30 @@
     =/  has  (~(has in open-link-requests) [(slav %p ship.pole) name.pole])
     ``json+!>([%b has])
   ::
-      [%x any %metadata token=@ ~]
-    =/  =metadata:reel  (fall (~(get by our-metadata) token.pole) *metadata:reel)
+      [%x %v1 %metadata ship=@ name=@ ~]
+    =/  id  (rap 3 ship.pole '/' name.pole ~)
+    =/  token  (~(get by stable-id) id)
+    ?~  token  [~ ~]
+    =/  =metadata:reel  (fall (~(get by our-metadata) u.token) *metadata:reel)
+    ``reel-metadata+!>(metadata)
+  ::
+      [%x %v0 %metadata name=@ ~]
+    ::  old style tokens are directly in metadata
+    =/  id  (rap 3 (scot %p our.bowl) '/' name.pole ~)
+    =/  =metadata:reel  (fall (~(get by our-metadata) id) *metadata:reel)
     ``reel-metadata+!>(metadata)
   ::
       [%x any %token-url token=*]
-    =/  =token:reel  (crip (join '/' token.pole))
+    =/  =token:reel  (crip +:(spud token.pole))
     =/  url  (url-for-token vic token)
-    ``reel-token-url+!>(url)
+    ``json+!>(s+url)
   ::
       [%x %v1 %id-url id=*]
-    =/  id  (crip (join '/' id.pole))
+    =/  id  (crip +:(spud id.pole))
     ?~  token=(~(get by stable-id) id)
-      ``reel-token-url+!>('')
-    =/  url  (cat 3 vic id)
-    ``reel-token-url+!>(url)
+      ``json+!>(s+'')
+    =/  url  (cat 3 vic u.token)
+    ``json+!>(s+url)
   ==
 ::
 ++  on-arvo

--- a/desk/ted/reel/set-ship.hoon
+++ b/desk/ted/reel/set-ship.hoon
@@ -11,7 +11,7 @@
 =/  url
   ?:  =(vic 'https://tlon.network/lure/')
     "https://tlon.network/v1/lure/bait/who"
-  "{(trip vic)}/bait/who"
+  "{(trip vic)}bait/who"
 ;<  =json  bind:m  (fetch-json url)
 =/  =ship  (slav %p (so:dejs:format json))
 ;<  ~  bind:m  (poke [our %reel] reel-command+!>([%set-ship ship]))

--- a/desk/tests/app/reel.hoon
+++ b/desk/tests/app/reel.hoon
@@ -20,7 +20,7 @@
   =/  m  (mare ,~)
   ;<  *  bind:m  (do-init dap reel-agent)
   ;<  *  bind:m  (jab-bowl |=(b=bowl b(our ~dev, src ~dev, now *@da)))
-  =/  =metadata:r  [%test (my ['inviter' '~dev'] ~)]
+  =/  =metadata:r  [%test (my ['inviter' '~dev'] ['group' '~bus/reel-test'] ~)]
   =/  describe  [token metadata]
   ;<  caz=(list card)  bind:m  (do-poke %reel-describe !>(describe))
   ;<  bw=bowl  bind:m  get-bowl


### PR DESCRIPTION
OTT, we weren't handling the grabbing the ID from the path correctly in the URL scries, and the metadata scry needed to be split between old and new versions. We previously weren't allowing you to rotate a particular group's token/metadata. This now correctly deletes the old data from the provider and gives new data, receiving a new token. There was also a small error in the set-ship thread where it had an extra slash. Finally we needed to include more metadata in the fields for invites and the DM we want to send.