### PR TITLE
reel: dont remove old tokens from provider

### DIFF
--- a/desk/app/reel.hoon
+++ b/desk/app/reel.hoon
@@ -150,9 +150,6 @@
     =.  open-describes  (~(put in open-describes) nonce)
     =.  stable-id  (~(put by stable-id) id nonce)
     :_  this
-    %+  welp
-      ?~  old-token  ~
-      ~[[%pass /undescribe %agent [civ %bait] %poke %bait-undescribe !>(u.old-token)]]
     ~[[%pass /describe %agent [civ %bait] %poke %bait-describe !>([nonce metadata])]]
   ::
       %reel-confirmation


### PR DESCRIPTION
We were removing old tokens here to prevent filling the lure provider too much, but that causes more problems than it solves. Since we're considering rebuilding this whole service lets just let them fill it up so links don't go bad.