### PR TITLE
contacts: remove unnecessary future check since we guard in fact intake

### DIFF
--- a/desk/app/contacts.hoon
+++ b/desk/app/contacts.hoon
@@ -238,11 +238,10 @@
     ::
     ++  p-init
       |=  wen=(unit @da)
+      ::  TODO: figure out if we can just give the profile every time
       ?~  wen  (give (fact ~ full+rof))
       ?:  =(u.wen wen.rof)  cor
-      ::
-      :: no future subs
-      ?>((lth u.wen wen.rof) (give (fact ~ full+rof)))
+      (give (fact ~ full+rof))
     ::  +p-news-0: [legacy] publish news
     ::
     ++  p-news-0

--- a/desk/app/contacts.hoon
+++ b/desk/app/contacts.hoon
@@ -238,9 +238,8 @@
     ::
     ++  p-init
       |=  wen=(unit @da)
-      ::  TODO: figure out if we can just give the profile every time
       ?~  wen  (give (fact ~ full+rof))
-      ?:  =(u.wen wen.rof)  cor
+      ?:  (gte u.wen wen.rof)  cor
       (give (fact ~ full+rof))
     ::  +p-news-0: [legacy] publish news
     ::


### PR DESCRIPTION
OTT, this is causing crashes for anyone trying to subscribe to someone who's breached or nuked contacts but hasn't updated their profile since.