### PR TITLE
Add scry/subscription paths for sovereign desks

### DIFF
--- a/desk/app/treaty.hoon
+++ b/desk/app/treaty.hoon
@@ -143,6 +143,10 @@
       [%allies ~]
     :_  this
     (fact-init:io (ally-update:cg:cc %ini allies))^~
+    ::
+      [%sovereign ~]
+    :_  this
+    (fact-init:io (sovereign-update:cg:cc %ini sovereign))^~
   ==
 ::
 ::

--- a/desk/app/treaty.hoon
+++ b/desk/app/treaty.hoon
@@ -154,6 +154,7 @@
     [%x %default-ally ~]  ``ship+!>(default-ally)
     [%x %allies ~]        ``(ally-update:cg:ca %ini allies)
     [%x %treaties ~]      ``(treaty-update:cg:ca:cc %ini treaties)
+    [%x %sovereign ~]     ``(sovereign-update:cg:ca:cc %ini sovereign)
   ::
      [%x %treaties @ ~]
     =/  =ship  (slav %p i.t.t.path)
@@ -309,6 +310,7 @@
   ++  alliance-update  |=(=update:alliance alliance-update-0+!>(update))
   ++  treaty  |=(t=^treaty treaty-0+!>(t))
   ++  treaty-update  |=(u=update:^treaty treaty-update-0+!>(u))
+  ++  sovereign-update  |=(u=update:^sovereign sovereign-update-0+!>(u))
   --
 ::  +ca: Card construction
 ++  ca

--- a/desk/app/treaty.hoon
+++ b/desk/app/treaty.hoon
@@ -96,8 +96,10 @@
       =,  update
       =.  entente  (~(del in entente) [ship desk])
       ?.  =(our.bowl ship)  `this
+      =/  so  ~(. so:cc desk)
       =.  sovereign  (~(del by sovereign) desk)
-      :_(this ~(kick so:cc desk)^~)
+      :_  this
+      [unpublish kick gone]:so
    ==
   --
 ::
@@ -367,8 +369,15 @@
     =/  t=treaty  (~(got by sovereign) desk)
     :~  (fact:io (treaty-update:cg %add t) /treaties ~)
         (fact:io (treaty:cg t) path ~)
+        (fact:io (sovereign-update:cg %add [desk t]) /sovereign ~)
     ==
+  ++  gone
+    ^-  (list card)
+    =/  t=treaty  (~(got by sovereign) desk)
+    (fact:io (sovereign-update:cg %del [desk t]) /sovereign ~)^~
   ++  publish
     (poke-our:pass %hood kiln-permission+!>([desk / &]))
+  ++  unpublish
+    (poke-our:pass %hood kiln-permission+!>([desk / |]))
   --
 --

--- a/desk/mar/sovereign-update-0.hoon
+++ b/desk/mar/sovereign-update-0.hoon
@@ -1,0 +1,13 @@
+/-  *treaty
+|_  =update:sovereign
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  update
+  --
+++  grab
+  |%
+  ++  noun  update:sovereign
+  --
+--
+

--- a/desk/sur/treaty.hoon
+++ b/desk/sur/treaty.hoon
@@ -34,7 +34,16 @@
         diff
     ==
   --
-
+::  +sovereign: Our published desks
+::
+++  sovereign
+  |%
+    +$  update
+      $%  [%ini (map =desk =treaty)]
+          [%add =desk =treaty]
+          [%del =desk =treaty]
+      ==
+  --
 ::  +ally: Discovery structures
 ::
 ++  ally


### PR DESCRIPTION
Primarily for Sky to track published/unpublished apps. Adds a scry for all sovereign desks and notifies subscribers of newly published and unpublished desks. Also adds an `+unpublish` arm which will explicitly toggle permissions on a desk when we unpublish it.