### PR TITLE
contacts: don't send activity events when first receiving remote profile

### DIFF
--- a/desk/app/contacts.hoon
+++ b/desk/app/contacts.hoon
@@ -356,7 +356,7 @@
                =?  cor  ?=(^ page)
                  ?:  =(con.u.page con.u)  cor
                  =.  book  (~(put by book) who u.page(con con.u))
-                 =.  cor  (emil (send-activity u con.u.page))
+                 =?  cor  ?=(^ for)  (emil (send-activity u con.u.page))
                  (p-response:pub %page who con.u mod.u.page)
                (p-response:pub %peer who con.u)
         ==


### PR DESCRIPTION
Checks to make sure we have previous data for that peer before emitting the changes as activity.

Fixes TLON-3346