### PR TITLE
contacts: ensure full deletion in +do-edit

### DIFF
--- a/desk/lib/contacts.hoon
+++ b/desk/lib/contacts.hoon
@@ -244,7 +244,7 @@
   =?  don  !=(~ del)
     %+  roll  del
     |=  [key=@tas acc=_don]
-    (~(del by don) key)
+    (~(del by acc) key)
   don
 ::  +from-0: legacy to new type
 ::


### PR DESCRIPTION
This was repeatedly deleting from the outer value, instead of the accumulator intended to replace it.

This would result in only a single key being deleted, even if an edit specified multiple keys for deletion.

Probable root-cause of the values that caused the crash described in tloncorp/tlon-apps#4281. I think the change there (on how it does the typechecks) is still good, since the types technically allow the null case, but also don't expect to strictly need it once this is behaving as intended.