### PR TITLE
Enable Lure flow logging in %reel and %bait

### DIFF
--- a/desk/app/bait.hoon
+++ b/desk/app/bait.hoon
@@ -1,5 +1,5 @@
 /-  reel
-/+  default-agent, verb, dbug, server, *reel
+/+  default-agent, verb, dbug, server, logs, *reel
 |%
 +$  card  card:agent:gall
 +$  versioned-state
@@ -64,8 +64,9 @@
 %-  agent:dbug
 %+  verb  |
 |_  =bowl:gall
-+*  this       .
-    def        ~(. (default-agent this %|) bowl)
++*  this  .
+    def   ~(. (default-agent this %|) bowl)
+    log   ~(. logs [our.bowl /logs])
 ::
 ++  on-init
   ^-  (quip card _this)
@@ -115,22 +116,24 @@
     ::
         %'POST'
       ?~  body.request
+        :-  (tell:log ~ %crit 'body not found' ~)
         (give-not-found 'body not found')
       ?.  =('ship=%7E' (end [3 8] q.u.body.request))
+        :-  (tell:log ~ %crit 'ship not found in body' ~)
         (give-not-found 'ship not found in body')
       =/  joiner  (slav %p (cat 3 '~' (rsh [3 8] q.u.body.request)))
       =;  [=bite:reel inviter=(unit ship)]
         ?~  inviter
+          :-  (tell:log `token.bite %crit 'inviter not found' ~)
           (give-not-found 'inviter not found')
         ^-  (list card)
-        ::  TODO: figure out if we need to send both pokes
-        :*  :*  %pass  /bite  %agent  [u.inviter %reel]
+        :*  %^  tell:log  `token.bite  %info
+            ~[leaf+"{<joiner>} redeemed lure invite from {<u.inviter>}"]
+            ::
+            :*  %pass  /bite  %agent  [u.inviter %reel]
                 %poke  %reel-bite  !>(bite)
             ==
-            :*  %pass  /bite  %agent  [our.bowl %reel]
-                %poke  %reel-bite  !>(bite)
-            ==
-            (give (manx-response:gen:server (sent-page joiner)))
+          (give (manx-response:gen:server (sent-page joiner)))
         ==
       =/  =(pole knot)  line
       ?:  ?=([@ @ ~] line)
@@ -220,5 +223,9 @@
     [~ this]
   ==
 ::
-++  on-fail   on-fail:def
+++  on-fail
+  |=  [=term =tang]
+  ^-  (quip card _this)
+  :_  this
+  [(fail:log term tang)]~
 --

--- a/desk/app/reel.hoon
+++ b/desk/app/reel.hoon
@@ -1,5 +1,5 @@
 /-  reel
-/+  default-agent, verb, dbug, *reel
+/+  default-agent, verb, dbug, logs, *reel
 |%
 +$  card  card:agent:gall
 +$  versioned-state
@@ -66,8 +66,9 @@
 %-  agent:dbug
 %+  verb  |
 |_  =bowl:gall
-+*  this       .
-    def        ~(. (default-agent this %|) bowl)
++*  this  .
+    def   ~(. (default-agent this %|) bowl)
+    log   ~(. logs [our.bowl /logs])
 ::
 ++  on-init
   ^-  (quip card _this)
@@ -174,6 +175,7 @@
     :_  this
     =/  url  (cat 3 vic token)
     =/  path  (stab (cat 3 '/v1/id-link/' id))
+    :-  (tell:log `token %info 'lure link generated' ~)
     ~[[%give %fact ~[path] %json !>(s+url)]]
   ::
       %reel-undescribe
@@ -298,7 +300,8 @@
       [%set-ship ~]
     ?>  ?=([%khan %arow *] sign-arvo)
     ?:  ?=(%.n -.p.sign-arvo)
-      ((slog 'reel: fetch bait ship failed' p.p.sign-arvo) `this)
+      :_  this
+      ~[(tell:log ~ %warn 'fetch bait ship failed' ~)]
     `this
   ::
       [%expire @ @ ~]
@@ -313,5 +316,9 @@
       (on-arvo:def wire sign-arvo)
     ==
   ==
-++  on-fail   on-fail:def
+++  on-fail
+  |=  [=term =tang]
+  ^-  (quip card _this)
+  :_  this
+  [(fail:log term tang)]~
 --

--- a/desk/lib/logs.hoon
+++ b/desk/lib/logs.hoon
@@ -62,6 +62,8 @@
         %tell
       =-  ?>(?=(%o -.-) -)
       %-  pairs:enjs
+      ::
+      ::  insert tell id if present
       =-  ?~  id.e  -
           [id/s+u.id.e -]
       :~  type/s+event-type

--- a/desk/lib/logs.hoon
+++ b/desk/lib/logs.hoon
@@ -1,0 +1,73 @@
+/-  *logs
+=<
+  |_  [our=ship =wire]
+  ::
+  ++  fail
+    |=  [desc=term trace=tang]
+    ^-  card:agent:gall
+    =/  event=$>(%fail log-event)
+      [%fail desc trace]
+    (pass event)
+  ::
+  ++  tell
+    |=  [id=(unit @ta) vol=volume =echo]
+    ^-  card:agent:gall
+    =/  event=$>(%tell log-event)
+      [%tell id vol echo]
+    (pass event)
+  ::
+  ++  pass
+    |=  event=log-event
+    ^-  card:agent:gall
+    [%pass wire %agent [our %logs] %poke log-action+!>([%log event])]
+  --
+|%
+::
+++  fail-event
+  |=  [=term =tang]
+  ^-  $>(%fail log-event)
+  [%fail term tang]
+::
+++  tell-event
+  |=  [id=(unit @ta) vol=volume =echo]
+  ^-  $>(%tell log-event)
+  [%tell id vol echo]
+::
+++  enjs
+  =,  format
+  |%
+  ++  tang
+    |=  t=^tang
+    ^-  $>(%a json)
+    ?~  t  a+~
+    =/  tame=(list tape)
+      %-  zing
+      %+  turn  t
+      (cury wash [0 80])
+    a+(turn tame tape:enjs)
+  ::
+  ++  log-event
+    |=  e=^log-event
+    ^-  $>(%o json)
+    =*  event-type  -.e
+    ?-    -.e
+        %fail
+      =-  ?>(?=(%o -.-) -)
+      %-  pairs:enjs
+      :~  type/s+event-type
+          description/s+desc.e
+          stacktrace/(tang trace.e)
+      ==
+    ::
+        %tell
+      =-  ?>(?=(%o -.-) -)
+      %-  pairs:enjs
+      =-  ?~  id.e  -
+          [id/s+u.id.e -]
+      :~  type/s+event-type
+          message/(tang echo.e)
+          volume/s+vol.e
+      ==
+    ==
+  --
+--

--- a/desk/sur/logs.hoon
+++ b/desk/sur/logs.hoon
@@ -15,7 +15,7 @@
       [%tell id=(unit @ta) vol=volume =echo]
   ==
 ::
-::  $log-item: an event with timestamp
+::  $log-item: event with timestamp
 +$  log-item  [=time event=log-event]
 ::
 +$  a-log

--- a/desk/sur/logs.hoon
+++ b/desk/sur/logs.hoon
@@ -1,0 +1,24 @@
+/+  mp=mop-extensions
+::
+|%
+::  $echo: formatted message
++$  echo  (list tank)
+::  $volume: echo volume
++$  volume  ?(%info %warn %crit)
+::  $log-event
+::
+::  %fail: agent failure
+::  %tell: agent message
+::
++$  log-event
+  $%  [%fail desc=term trace=tang]
+      [%tell id=(unit @ta) vol=volume =echo]
+  ==
+::
+::  $log-item: an event with timestamp
++$  log-item  [=time event=log-event]
+::
++$  a-log
+  $%  [%log log-event]
+  ==
+--


### PR DESCRIPTION
Lure backend infrastructure comprises of three agents: %grouper, %reel and %bait.
This PR augments %reel and %bait with Lure invite and redemption tracing, as described in detail in TLON-3378.

Companion PR: https://github.com/tloncorp/tlon-apps/pull/4308

Closes TLON-3378