### PR TITLE
reel: move stable id check higher to improve log message

### DIFF
--- a/desk/app/reel.hoon
+++ b/desk/app/reel.hoon
@@ -157,11 +157,6 @@
     ?>  =(civ src.bowl)
     =+  !<(confirmation:reel vase)
     =.  open-describes  (~(del in open-describes) nonce)
-    ?~  md=(~(get by our-metadata) nonce)
-      :_  this  :_  ~
-      %^  tell:log  %crit
-        ~[leaf+"failed to receive metadata for nonce {<nonce>}"]
-      ~['event'^s+'Invite Creation Failed' 'flow'^s+'lure']
     =/  ids=(list [id=cord =token:reel])
       %+  skim
         ~(tap by stable-id)
@@ -169,10 +164,15 @@
       =(nonce token)
     ?~  ids
       :_  this  :_  ~
-      %^  tell:log  %crit
+      %^  tell:log  %warn
         ~[leaf+"no stable id found for nonce {<nonce>}"]
-      ~['event'^s+'Invite Creation Failed' 'flow'^s+'lure']
+      ~['event'^s+'Nonce Revoked' 'flow'^s+'lure']
     =*  id  -<.ids
+    ?~  md=(~(get by our-metadata) nonce)
+      :_  this  :_  ~
+      %^  tell:log  %crit
+        ~[leaf+"no metadata for nonce {<nonce>}"]
+      ~['event'^s+'Invite Creation Failed' 'flow'^s+'lure']
     ::  update the token the id points to
     =.  stable-id  (~(put by stable-id) id token)
     ::  swap out the nonce for the token in our-metadata

--- a/desk/mar/reel/describe.hoon
+++ b/desk/mar/reel/describe.hoon
@@ -4,7 +4,7 @@
 ++  grad  %noun
 ++  grab
   |%
-  ++  noun  (pair cord cord)
+  ++  noun  [token:reel metadata:reel]
   ++  json  (ot:dejs:format ~[token+so:dejs:format metadata+dejs-metadata])
   --
 ++  grow


### PR DESCRIPTION
We have cases where we try to describe multiple times before we ever hear back about the confirmation. This moves the check for stable id higher so that we can be more clear about what's happening.