### PR TITLE
ops: update artifact actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           npm ci
           npm run build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: 'ui-dist'
           path:  ui/dist
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.tag }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: 'ui-dist'
           path: ui/dist


### PR DESCRIPTION
Github deprecated the version we were using, should be same usage in our case https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/