### PR TITLE
docket: serve glob upload page with content-type

### DIFF
--- a/desk/app/docket.hoon
+++ b/desk/app/docket.hoon
@@ -531,7 +531,7 @@
       (rap 3 'window.ship = "' (rsh 3 (scot %p our.bowl)) '";' ~)
     ::
         [[%docket %upload ~] ?(~ [~ %html])]
-      [[200 ~] `(upload-page ~)]
+      [[200 ['content-type' 'text/html']~] `(upload-page ~)]
     ::
         [[%apps @ *] *]
       %+  payload-from-glob


### PR DESCRIPTION
Without this, under rare circumstances (for example, a middle-man injecting `X-Content-Type-Options: nosniff` headers), browsers may not display this as a normal html page.