### PR TITLE
vitals: improve checks for sponsored targets, switch to %ping

### DIFF
--- a/desk/app/vitals.hoon
+++ b/desk/app/vitals.hoon
@@ -124,13 +124,17 @@
       %run-check
     ?>  =(our src)
     =+  !<(=ship vase)
-    ::  allow checks for descendants in sponsor chain, plus direct own-moon case
-    ::  (moon sponsor relation can be determined locally without saxo lookup)
-    ?>  ?|  =(~ (find ~[our] (saxo:title our now ship)))
-            ?&  ?=(%earl (clan:title ship))
-                =(our (end 5 ship))
-            ==
-        ==
+    =/  in-chain=?  !=(~ (find ~[our] (saxo:title our now ship)))
+    =/  own-moon=?
+      ?&  ?=(%earl (clan:title ship))
+          =(our (end 5 ship))
+      ==
+    =/  check-thread=@tas
+      ?:  ?|  in-chain
+              own-moon
+          ==
+        %vitals-sponsored-connection-check
+      %vitals-connection-check
     =/  stat=(unit result:v)  (~(get by connections) ship)
     ::  XX: code duplicated because of annoying type issue
     ?~  stat
@@ -142,7 +146,7 @@
           %k
           %fard
           %landscape
-          %vitals-connection-check
+          check-thread
           %noun
           !>((some ship))
       ==
@@ -157,7 +161,7 @@
         %k
         %fard
         %landscape
-        %vitals-connection-check
+        check-thread
         %noun
         !>((some ship))
     ==

--- a/desk/app/vitals.hoon
+++ b/desk/app/vitals.hoon
@@ -125,14 +125,8 @@
     ?>  =(our src)
     =+  !<(=ship vase)
     =/  in-chain=?  !=(~ (find ~[our] (saxo:title our now ship)))
-    =/  own-moon=?
-      ?&  ?=(%earl (clan:title ship))
-          =(our (end 5 ship))
-      ==
     =/  check-thread=@tas
-      ?:  ?|  in-chain
-              own-moon
-          ==
+      ?:  in-chain
         %vitals-sponsored-connection-check
       %vitals-connection-check
     =/  stat=(unit result:v)  (~(get by connections) ship)

--- a/desk/app/vitals.hoon
+++ b/desk/app/vitals.hoon
@@ -124,7 +124,13 @@
       %run-check
     ?>  =(our src)
     =+  !<(=ship vase)
-    ?>  =(~ (find ~[our] (saxo:title our now ship)))
+    ::  allow checks for descendants in sponsor chain, plus direct own-moon case
+    ::  (moon sponsor relation can be determined locally without saxo lookup)
+    ?>  ?|  =(~ (find ~[our] (saxo:title our now ship)))
+            ?&  ?=(%earl (clan:title ship))
+                =(our (end 5 ship))
+            ==
+        ==
     =/  stat=(unit result:v)  (~(get by connections) ship)
     ::  XX: code duplicated because of annoying type issue
     ?~  stat

--- a/desk/lib/vitals.hoon
+++ b/desk/lib/vitals.hoon
@@ -1,4 +1,5 @@
-/-  vitals
+/-  vitals, spider
+/+  io=strandio
 |%
 ++  simplify-qos
   |=  =ship-state:ames
@@ -8,6 +9,7 @@
     %known  ?+  -.qos.ship-state  qos.ship-state
               %unborn   [%dead last-contact.qos.ship-state]
   ==        ==
+::
 ++  scry-qos
   |=  [=ship =time peer=ship]
   ^-  qos:ames
@@ -23,4 +25,96 @@
     [%unborn time]
   =/  pqos  .^(ship-state:ames (snoc ames-peers (scot %p peer)))
   (simplify-qos pqos)
+::
+::  thread helpers ::::::::::::::::::::::::::::::::::::
+::
+::  thread version of +scry-qos
+++  get-qos
+  |=  peer=ship
+  =/  m  (strand:spider ,qos:ames)
+  ^-  form:m
+  ;<  our=@p  bind:m  get-our:io
+  ;<  now=@da  bind:m  get-time:io
+  ?:  =(our peer)
+    (pure:m [%live now])
+  ;<  peers=(map ship ?(%alien %known))  bind:m
+    (scry:io (map ship ?(%alien %known)) ~[%ax %$ %peers])
+  ?.  (~(has by peers) peer)
+    (pure:m [%unborn now])
+  ;<  state=ship-state:ames  bind:m
+    (scry:io ship-state:ames ~[%ax %$ %peers (scot %p peer)])
+  (pure:m (simplify-qos state))
+::
+++  update-status
+  |=  [target=ship =pending:vitals]
+  =/  m  (strand:spider ,~)
+  ^-  form:m
+  ;<  now=@da  bind:m  get-time:io
+  %+  poke-our:io
+    %vitals
+  :-  %update-status
+  !>
+  ^-  update:vitals
+  [target now %pending pending]
+::
+++  post-result
+  |=  =complete:vitals
+  =/  m  (strand:spider ,vase)
+  ^-  form:m
+  (pure:m !>(complete))
+::
+++  ask-sponsor
+  |=  [sponsor=ship target=ship]
+  =/  m  (strand:spider ,(unit ?))
+  ^-  form:m
+  %-  (handle-err ,?)
+  %+  (set-timeout:io ,?)  target-timeout:vitals
+  ::  XX: currently returns [~ |] if the sponsor doesn't have %vitals running
+  ;<    ~
+      bind:(strand:spider ,?)
+    %-  send-raw-card:io
+    :*  %pass
+        /poke
+        %agent
+        [sponsor %vitals]
+        %poke
+        %ship
+        !>(target)
+    ==
+  |=  tin=strand-input:strand:spider
+  ?+  in.tin  `[%skip ~]
+      ~  `[%wait ~]
+  ::
+      [~ %agent * %poke-ack *]
+    ?.  =(/poke wire.u.in.tin)
+      `[%skip ~]
+    ?~  p.sign.u.in.tin
+      `[%done &]
+    `[%done |]
+  ==
+::
+++  check-online
+  |=  [who=ship lag=@dr]
+  =/  m  (strand:spider ,(unit))
+  ^-  form:m
+  %-  (handle-err ,~)
+  %+  (set-timeout:io ,~)  lag
+  =/  n  (strand:spider ,~)
+  ;<  ~  bind:n  (poke:io [who %ping] %noun !>(~))
+  (pure:n ~)
+::
+++  handle-err
+  |*  computation-result=mold
+  =/  m  (strand:spider ,(unit computation-result))
+  =/  n  (strand:spider ,computation-result)
+  |=  computation=form:n
+  ^-  form:m
+  |=  tin=strand-input:strand:spider
+  =*  loop  $
+  =/  c-res  (computation tin)
+  ?+  -.next.c-res  c-res
+    %cont  c-res(self.next ..loop(computation self.next.c-res))
+    %fail  c-res(next [%done ~])
+    %done  c-res(value.next (some value.next.c-res))
+  ==
 --

--- a/desk/ted/vitals/connection-check.hoon
+++ b/desk/ted/vitals/connection-check.hoon
@@ -96,6 +96,14 @@
     :: ... otherwise, check next sponsor
     $(sponsors t.sponsors)
   ::  report whether sponsor can reach target
+  ::
+  ::  if the target is our moon and we are the sponsor reporting %live,
+  ::  treat that as a successful direct path for this check.
+  ?:  ?&  u.live
+          ?=(%earl (clan:title target))
+          =(i.sponsors our)
+      ==
+    (post-result [%yes ~])
   %-  post-result
   ?:  u.live
     [%no-sponsor-hit i.sponsors]

--- a/desk/ted/vitals/connection-check.hoon
+++ b/desk/ted/vitals/connection-check.hoon
@@ -3,8 +3,8 @@
 ::      completes, but instead record the results and then check them after some
 ::      timeout (e.g. 30s).
 ::
-/-  spider, vitals
-/+  io=strandio, lib-vitals=vitals
+/-  v=vitals, spider
+/+  *vitals, io=strandio
 =,  strand=strand:spider
 ^-  thread:spider
 |=  arg=vase
@@ -17,12 +17,12 @@
   ;<  tqos=qos:ames  bind:m  (get-qos target)
   ;<  now=@da  bind:m  get-time:io
   ?:  ?&  ?=(%live -.tqos)
-          (gth last-contact.tqos (sub now info-timeout:vitals))
+          (gth last-contact.tqos (sub now info-timeout:v))
       ==
     (post-result [%yes ~])
   ::  set pending to %trying-dns
   ::  XX: can we use the strand cards for these?
-  ;<  ~  bind:m  (update-status [%trying-dns ~])
+  ;<  ~  bind:m  (update-status target [%trying-dns ~])
   ::  check if we can fetch example.com
   ;<  ~  bind:m  (send-request:io [%'GET' 'http://example.com' ~ ~])
   ;<  =client-response:iris  bind:m  take-client-response:io
@@ -31,16 +31,16 @@
       ==
     (post-result [%no-dns ~])
   ::  set pending to %trying-local
-  ;<  ~  bind:m  (update-status [%trying-local ~])
+  ;<  ~  bind:m  (update-status target [%trying-local ~])
   ::  check if we can contact our own galaxy
-  ;<  =ping:vitals  bind:m  (scry:io ping:vitals ~[%gx %ping %noun])
+  ;<  =ping:v  bind:m  (scry:io ping:v ~[%gx %ping %noun])
   ;<  gqos=qos:ames  bind:m  (scry:io qos:ames ~[%gx %vitals %galaxy %vitals-qos])
   ?:  !(galaxy-reachable ping gqos)
     (post-result [%no-our-galaxy last-contact.gqos])
   ::  set pending to %trying-target
-  ;<  ~  bind:m  (update-status [%trying-target ~])
+  ;<  ~  bind:m  (update-status target [%trying-target ~])
   ::  check if we can contact target (with timeout)
-  ;<  chek=(unit)  bind:m  (check-online target target-timeout:vitals)
+  ;<  chek=(unit)  bind:m  (check-online target target-timeout:v)
   ?:  ?=([%$ %$] chek)
     (post-result [%yes ~])
   ::  if we're a moon, check if we can contact our planet
@@ -61,8 +61,8 @@
     ?.  ?=(%earl (clan:title our))
       (pure:mm %.y)
     =/  sponsor=@p  (end 5 our)
-    ;<  ~  bind:mm  (update-status [%trying-sponsor sponsor])
-    ;<  pchek=(unit)   bind:mm  (check-online sponsor target-timeout:vitals)
+    ;<  ~  bind:mm  (update-status target [%trying-sponsor sponsor])
+    ;<  pchek=(unit)   bind:mm  (check-online sponsor target-timeout:v)
     ?:  ?=([%$ %$] pchek)
       (pure:mm %.y)
     (pure:mm %.n)
@@ -84,9 +84,9 @@
   ::    - base case is sponsor = galaxy
   ?~  sponsors  !!
   ::  set pending to %trying-sponsor
-  ;<  ~  bind:m  (update-status [%trying-sponsor i.sponsors])
+  ;<  ~  bind:m  (update-status target [%trying-sponsor i.sponsors])
   ::  ask sponsor if he has live wire to target
-  ;<  live=(unit ?)  bind:m  (ask-sponsor i.sponsors)
+  ;<  live=(unit ?)  bind:m  (ask-sponsor i.sponsors target)
   ::  if timeout...
   ?~  live
     ::  ... and sponsor is galaxy ...
@@ -102,7 +102,7 @@
   [%no-sponsor-miss i.sponsors]
 ::
 ++  galaxy-reachable
-  |=  [=ping:vitals =qos:ames]
+  |=  [=ping:v =qos:ames]
   ^-  ?
   ?-    -.ping
       %0
@@ -124,93 +124,10 @@
     ?=(%live -.qos)
   ==
 ::
-++  update-status
-  |=  =pending:vitals
-  =/  m  (strand ,~)
-  ^-  form:m
-  ;<  now=@da  bind:m  get-time:io
-  %+  poke-our:io
-    %vitals
-  :-  %update-status
-  !>
-  ^-  update:vitals
-  [target now %pending pending]
-::  thread version of +scry-qos in /=landscape=/lib/vitals/hoon
-++  get-qos
-  |=  peer=ship
-  =/  m  (strand ,qos:ames)
-  ^-  form:m
-  ;<  now=@da  bind:m  get-time:io
-  ?:  =(our peer)
-    (pure:m [%live now])
-  ;<  peers=(map ship ?(%alien %known))  bind:m
-    (scry:io (map ship ?(%alien %known)) ~[%ax %$ %peers])
-  ?.  (~(has by peers) peer)
-    (pure:m [%unborn now])
-  ;<  state=ship-state:ames  bind:m
-    (scry:io ship-state:ames ~[%ax %$ %peers (scot %p peer)])
-  (pure:m (simplify-qos:lib-vitals state))
 ++  galaxy-down
   |=  galaxy=ship
   =/  m  (strand ,vase)
   ^-  form:m
   ;<  =qos:ames  bind:m  (get-qos galaxy)
   (post-result [%no-their-galaxy last-contact.qos])
-++  post-result
-  |=  =complete:vitals
-  =/  m  (strand ,vase)
-  ^-  form:m
-  (pure:m !>(complete))
-++  ask-sponsor
-  |=  sponsor=ship
-  =/  m  (strand ,(unit ?))
-  ^-  form:m
-  %-  (handle-err ,?)
-  %+  (set-timeout:io ,?)  target-timeout:vitals
-  ::  XX: currently returns [~ |] if the sponsor doesn't have %vitals running
-  ;<    ~
-      bind:(strand ,?)
-    %-  send-raw-card:io
-    :*  %pass
-        /poke
-        %agent
-        [sponsor %vitals]
-        %poke
-        %ship
-        !>(target)
-    ==
-  |=  tin=strand-input:strand
-  ?+  in.tin  `[%skip ~]
-      ~  `[%wait ~]
-  ::
-      [~ %agent * %poke-ack *]
-    ?.  =(/poke wire.u.in.tin)
-      `[%skip ~]
-    ?~  p.sign.u.in.tin
-      `[%done &]
-    `[%done |]
-  ==
-++  check-online
-  |=  [who=ship lag=@dr]
-  =/  m  (strand ,(unit))
-  ^-  form:m
-  %-  (handle-err ,~)
-  %+  (set-timeout:io ,~)  lag
-  =/  n  (strand ,~)
-  ;<  ~  bind:n  (poke:io [who %hood] %helm-hi !>(~))
-  (pure:n ~)
-++  handle-err
-  |*  computation-result=mold
-  =/  m  (strand ,(unit computation-result))
-  =/  n  (strand ,computation-result)
-  |=  computation=form:n
-  ^-  form:m
-  |=  tin=strand-input:strand
-  =*  loop  $
-  =/  c-res  (computation tin)
-  ?+  -.next.c-res  c-res
-    %cont  c-res(self.next ..loop(computation self.next.c-res))
-    %fail  c-res(next [%done ~])
-    %done  c-res(value.next (some value.next.c-res))
-  ==
 --

--- a/desk/ted/vitals/sponsored-connection-check.hoon
+++ b/desk/ted/vitals/sponsored-connection-check.hoon
@@ -30,13 +30,15 @@
   (post-result [%no-sponsor-miss our])
 =/  sponsor=ship  i.sponsors
 ;<  ~  bind:m  (update-status target [%trying-sponsor sponsor])
-;<  live=(unit ?)  bind:m  (ask-sponsor sponsor target)
+;<  live=(unit ?)  bind:m
+  ::  we know we ourselves are live so can short circuit
+  ?:  =(our sponsor)  (pure:(strand (unit ?)) `&)
+  (ask-sponsor sponsor target)
 ?~  live
-  ?:  =(sponsor our)
-    (post-result [%no-sponsor-miss sponsor])
   $(sponsors t.sponsors)
 ?:  u.live
-  ?:  =(sponsor our)
+  ::  if we're a not a star, we're done, otherwise we need to check galaxy
+  ?:  &(=(sponsor our) !?=(%king (clan:title our)))
     (post-result [%yes ~])
   $(sponsors t.sponsors)
 (post-result [%no-sponsor-miss sponsor])

--- a/desk/ted/vitals/sponsored-connection-check.hoon
+++ b/desk/ted/vitals/sponsored-connection-check.hoon
@@ -1,10 +1,5 @@
-::  XX: As an alternative implementation, we could perform these checks (mostly)
-::      in parallel. In that case, we shouldn't return immediately when a check
-::      completes, but instead record the results and then check them after some
-::      timeout (e.g. 30s).
-::
-/-  spider, vitals
-/+  io=strandio, lib-vitals=vitals
+/-  v=vitals, spider
+/+  *vitals, io=strandio
 =,  strand=strand:spider
 ^-  thread:spider
 |=  arg=vase
@@ -12,144 +7,36 @@
 ^-  form:m
 =+  !<([~ target=ship] arg)
 ;<  our=@p  bind:m  get-our:io
-|^
-  ::  sponsored-target check: only evaluate path to target and sponsor chain
-  ::  (skip global DNS/local-galaxy diagnostics used by generic checks)
-  ;<  ~  bind:m  (update-status [%trying-target ~])
-  ;<  chek=(unit)  bind:m  (check-online target target-timeout:vitals)
-  ?:  ?=([%$ %$] chek)
-    (post-result [%yes ~])
-  ::  walk target's sponsor chain toward us
-  ;<  saxo=(list ship)  bind:m  (scry:io (list ship) ~[%j %saxo (scot %p target)])
-  =/  sponsors
-    ?~  saxo  ~
-    t.saxo
-  |-
-  ?~  sponsors
-    (post-result [%no-sponsor-miss our])
-  =/  sponsor=ship  i.sponsors
-  ;<  ~  bind:m  (update-status [%trying-sponsor sponsor])
-  ;<  live=(unit ?)  bind:m  (ask-sponsor sponsor)
-  ?~  live
-    ?:  =(sponsor our)
-      (post-result [%no-sponsor-miss sponsor])
-    $(sponsors t.sponsors)
-  ?:  u.live
-    ?:  =(sponsor our)
-      (post-result [%yes ~])
-    $(sponsors t.sponsors)
-  (post-result [%no-sponsor-miss sponsor])
-::
-++  galaxy-reachable
-  |=  [=ping:vitals =qos:ames]
-  ^-  ?
-  ?-    -.ping
-      %0
-    ?=(%live -.qos)
-  ::
-      %1
-    ?:  ?=(%pub -.plan.ping)
-      %.y
-    ?=(%live -.qos)
-  ::
-      %2
-    ?.  ?=(%nat -.plan.ping)
-      %.y
-    ?=(%live -.qos)
-  ::
-      %3
-    ?:  ?=(%informal mode.ping)
-      %.y
-    ?=(%live -.qos)
-  ==
-::
-++  update-status
-  |=  =pending:vitals
-  =/  m  (strand ,~)
-  ^-  form:m
-  ;<  now=@da  bind:m  get-time:io
-  %+  poke-our:io
-    %vitals
-  :-  %update-status
-  !>
-  ^-  update:vitals
-  [target now %pending pending]
-::  thread version of +scry-qos in /=landscape=/lib/vitals/hoon
-++  get-qos
-  |=  peer=ship
-  =/  m  (strand ,qos:ames)
-  ^-  form:m
-  ;<  now=@da  bind:m  get-time:io
-  ?:  =(our peer)
-    (pure:m [%live now])
-  ;<  peers=(map ship ?(%alien %known))  bind:m
-    (scry:io (map ship ?(%alien %known)) ~[%ax %$ %peers])
-  ?.  (~(has by peers) peer)
-    (pure:m [%unborn now])
-  ;<  state=ship-state:ames  bind:m
-    (scry:io ship-state:ames ~[%ax %$ %peers (scot %p peer)])
-  (pure:m (simplify-qos:lib-vitals state))
-++  galaxy-down
-  |=  galaxy=ship
-  =/  m  (strand ,vase)
-  ^-  form:m
-  ;<  =qos:ames  bind:m  (get-qos galaxy)
-  (post-result [%no-their-galaxy last-contact.qos])
-++  post-result
-  |=  =complete:vitals
-  =/  m  (strand ,vase)
-  ^-  form:m
-  (pure:m !>(complete))
-++  ask-sponsor
-  |=  sponsor=ship
-  =/  m  (strand ,(unit ?))
-  ^-  form:m
-  %-  (handle-err ,?)
-  %+  (set-timeout:io ,?)  target-timeout:vitals
-  ::  XX: currently returns [~ |] if the sponsor doesn't have %vitals running
-  ;<    ~
-      bind:(strand ,?)
-    %-  send-raw-card:io
-    :*  %pass
-        /poke
-        %agent
-        [sponsor %vitals]
-        %poke
-        %ship
-        !>(target)
+::  early exit; check if we have live path to target
+;<  tqos=qos:ames  bind:m  (get-qos target)
+;<  now=@da  bind:m  get-time:io
+?:  ?&  ?=(%live -.tqos)
+        (gth last-contact.tqos (sub now info-timeout:v))
     ==
-  |=  tin=strand-input:strand
-  ?+  in.tin  `[%skip ~]
-      ~  `[%wait ~]
-  ::
-      [~ %agent * %poke-ack *]
-    ?.  =(/poke wire.u.in.tin)
-      `[%skip ~]
-    ?~  p.sign.u.in.tin
-      `[%done &]
-    `[%done |]
-  ==
-++  check-online
-  |=  [who=ship lag=@dr]
-  =/  m  (strand ,(unit))
-  ^-  form:m
-  %-  (handle-err ,~)
-  %+  (set-timeout:io ,~)  lag
-  =/  n  (strand ,~)
-  ;<  ~  bind:n  (poke:io [who %hood] %helm-hi !>(~))
-  (pure:n ~)
-++  handle-err
-  |*  computation-result=mold
-  =/  m  (strand ,(unit computation-result))
-  =/  n  (strand ,computation-result)
-  |=  computation=form:n
-  ^-  form:m
-  |=  tin=strand-input:strand
-  =*  loop  $
-  =/  c-res  (computation tin)
-  ?+  -.next.c-res  c-res
-    %cont  c-res(self.next ..loop(computation self.next.c-res))
-    %fail  c-res(next [%done ~])
-    %done  c-res(value.next (some value.next.c-res))
-  ==
---
+  (post-result [%yes ~])
+::  sponsored-target check: only evaluate path to target and sponsor chain
+::  (skip global DNS/local-galaxy diagnostics used by generic checks)
+;<  ~  bind:m  (update-status target [%trying-target ~])
+;<  chek=(unit)  bind:m  (check-online target target-timeout:v)
+?:  ?=([%$ %$] chek)
+  (post-result [%yes ~])
+::  walk target's sponsor chain toward us
+;<  saxo=(list ship)  bind:m  (scry:io (list ship) ~[%j %saxo (scot %p target)])
+=/  sponsors
+  ?~  saxo  ~
+  t.saxo
+|-
+?~  sponsors
+  (post-result [%no-sponsor-miss our])
+=/  sponsor=ship  i.sponsors
+;<  ~  bind:m  (update-status target [%trying-sponsor sponsor])
+;<  live=(unit ?)  bind:m  (ask-sponsor sponsor target)
+?~  live
+  ?:  =(sponsor our)
+    (post-result [%no-sponsor-miss sponsor])
+  $(sponsors t.sponsors)
+?:  u.live
+  ?:  =(sponsor our)
+    (post-result [%yes ~])
+  $(sponsors t.sponsors)
+(post-result [%no-sponsor-miss sponsor])

--- a/desk/ted/vitals/sponsored-connection-check.hoon
+++ b/desk/ted/vitals/sponsored-connection-check.hoon
@@ -96,6 +96,14 @@
     :: ... otherwise, check next sponsor
     $(sponsors t.sponsors)
   ::  report whether sponsor can reach target
+  ::
+  ::  if the target is our moon and we are the sponsor reporting %live,
+  ::  treat that as a successful direct path for this check.
+  ?:  ?&  u.live
+          ?=(%earl (clan:title target))
+          =(i.sponsors our)
+      ==
+    (post-result [%yes ~])
   %-  post-result
   ?:  u.live
     [%no-sponsor-hit i.sponsors]

--- a/desk/ted/vitals/sponsored-connection-check.hoon
+++ b/desk/ted/vitals/sponsored-connection-check.hoon
@@ -13,101 +13,32 @@
 =+  !<([~ target=ship] arg)
 ;<  our=@p  bind:m  get-our:io
 |^
-  ::  early exit; check if we have live path to target
-  ;<  tqos=qos:ames  bind:m  (get-qos target)
-  ;<  now=@da  bind:m  get-time:io
-  ?:  ?&  ?=(%live -.tqos)
-          (gth last-contact.tqos (sub now info-timeout:vitals))
-      ==
-    (post-result [%yes ~])
-  ::  set pending to %trying-dns
-  ::  XX: can we use the strand cards for these?
-  ;<  ~  bind:m  (update-status [%trying-dns ~])
-  ::  check if we can fetch example.com
-  ;<  ~  bind:m  (send-request:io [%'GET' 'http://example.com' ~ ~])
-  ;<  =client-response:iris  bind:m  take-client-response:io
-  ?.  ?&  ?=(%finished -.client-response)
-          =(200 status-code.response-header.client-response)
-      ==
-    (post-result [%no-dns ~])
-  ::  set pending to %trying-local
-  ;<  ~  bind:m  (update-status [%trying-local ~])
-  ::  check if we can contact our own galaxy
-  ;<  =ping:vitals  bind:m  (scry:io ping:vitals ~[%gx %ping %noun])
-  ;<  gqos=qos:ames  bind:m  (scry:io qos:ames ~[%gx %vitals %galaxy %vitals-qos])
-  ?:  !(galaxy-reachable ping gqos)
-    (post-result [%no-our-galaxy last-contact.gqos])
-  ::  set pending to %trying-target
+  ::  sponsored-target check: only evaluate path to target and sponsor chain
+  ::  (skip global DNS/local-galaxy diagnostics used by generic checks)
   ;<  ~  bind:m  (update-status [%trying-target ~])
-  ::  check if we can contact target (with timeout)
   ;<  chek=(unit)  bind:m  (check-online target target-timeout:vitals)
   ?:  ?=([%$ %$] chek)
     (post-result [%yes ~])
-  ::  if we're a moon, check if we can contact our planet
-  ::
-  ::  NN: failing to contact our sponsor is only a failure condition for moons,
-  ::      since currently only moons require the direct sponsor to be online for
-  ::      peers to grab the moon keys
-  ::  NN: we do this after the initial target check because if we're a moon and
-  ::      our planet is down, it's useful to talk to ships that still have live
-  ::      wires (e.g. for troubleshooting); thus, by waiting to perform this
-  ::      check, we don't report %no-our-planet for every connectivity check
-  ::      when attempting to track down a live peer from whom to seek help
-  ::
-  ;<  moon-sponsor-reachable=?
-      bind:m
-    =/  mm  (strand ,?)
-    ^-  form:mm
-    ?.  ?=(%earl (clan:title our))
-      (pure:mm %.y)
-    =/  sponsor=@p  (end 5 our)
-    ;<  ~  bind:mm  (update-status [%trying-sponsor sponsor])
-    ;<  pchek=(unit)   bind:mm  (check-online sponsor target-timeout:vitals)
-    ?:  ?=([%$ %$] pchek)
-      (pure:mm %.y)
-    (pure:mm %.n)
-  ::
-  ?:  !moon-sponsor-reachable
-    ;<  pqos=qos:ames  bind:m  (scry:io qos:ames ~[%gx %vitals %sponsor %vitals-qos])
-    (post-result [%no-our-planet last-contact.pqos])
-  ::  early exit; if target is a galaxy, there's nothing more we can check
-  ?:  ?=(%czar (clan:title target))
-    (galaxy-down target)
-  ::  check if target sponsors can reach target
+  ::  walk target's sponsor chain toward us
   ;<  saxo=(list ship)  bind:m  (scry:io (list ship) ~[%j %saxo (scot %p target)])
   =/  sponsors
     ?~  saxo  ~
     t.saxo
   |-
-  ::  case impossible:
-  ::    - early exit for target = galaxy
-  ::    - base case is sponsor = galaxy
-  ?~  sponsors  !!
-  ::  set pending to %trying-sponsor
-  ;<  ~  bind:m  (update-status [%trying-sponsor i.sponsors])
-  ::  ask sponsor if he has live wire to target
-  ;<  live=(unit ?)  bind:m  (ask-sponsor i.sponsors)
-  ::  if timeout...
+  ?~  sponsors
+    (post-result [%no-sponsor-miss our])
+  =/  sponsor=ship  i.sponsors
+  ;<  ~  bind:m  (update-status [%trying-sponsor sponsor])
+  ;<  live=(unit ?)  bind:m  (ask-sponsor sponsor)
   ?~  live
-    ::  ... and sponsor is galaxy ...
-    ?:  ?=(%czar (clan:title i.sponsors))
-      ::  ... it's so over
-      (galaxy-down i.sponsors)
-    :: ... otherwise, check next sponsor
+    ?:  =(sponsor our)
+      (post-result [%no-sponsor-miss sponsor])
     $(sponsors t.sponsors)
-  ::  report whether sponsor can reach target
-  ::
-  ::  if the target is our moon and we are the sponsor reporting %live,
-  ::  treat that as a successful direct path for this check.
-  ?:  ?&  u.live
-          ?=(%earl (clan:title target))
-          =(i.sponsors our)
-      ==
-    (post-result [%yes ~])
-  %-  post-result
   ?:  u.live
-    [%no-sponsor-hit i.sponsors]
-  [%no-sponsor-miss i.sponsors]
+    ?:  =(sponsor our)
+      (post-result [%yes ~])
+    $(sponsors t.sponsors)
+  (post-result [%no-sponsor-miss sponsor])
 ::
 ++  galaxy-reachable
   |=  [=ping:vitals =qos:ames]


### PR DESCRIPTION
This PR addresses TLON-5448 by special casing targets that are in our sponsor chain. For them we run a stripped down check. This works with planet -> moon, but I haven't tried star -> planet or star -> planet moon. I also changed the app we poke to %ping, to prevent leaking activity to the target's dojo. Finally since these share a lot of code I took the time to move that into the vitals lib.