### PR TITLE
tile: greyscale images on suspended app tiles

### DIFF
--- a/ui/src/tiles/Tile.tsx
+++ b/ui/src/tiles/Tile.tsx
@@ -125,7 +125,10 @@ export const Tile: FunctionComponent<TileProps> = ({
         )}
         {image && status !== 'installing' && (
           <img
-            className="absolute top-0 left-0 h-full w-full object-cover"
+            className={classNames(
+              'absolute top-0 left-0 h-full w-full object-cover',
+              suspended && 'grayscale'
+            )}
             src={image}
             alt=""
           />


### PR DESCRIPTION
## Summary
- Applies the `grayscale` CSS filter directly on tile `<img>` elements when the app is suspended, ensuring images render in greyscale rather than full color.
- The existing `grayscale` class on the parent `<a>` wasn't reliably cascading to images due to Tailwind v2's CSS custom property filter composition.

Fixes #211

## Test plan
- [ ] Suspend an app that has a tile image (e.g. via dojo `:hood &hood-do [%suspend %desk-name]`)
- [ ] Verify the tile image appears greyscale and faded
- [ ] Verify active app tiles still display images in full color

🤖 Generated with [Claude Code](https://claude.com/claude-code)