### PR TITLE
deploy: unmount desk before mounting

### DIFF
--- a/.github/helpers/deploy.sh
+++ b/.github/helpers/deploy.sh
@@ -81,6 +81,7 @@ cat > "$cmdfile" <<EOF
 staging=\$(mktemp -d)
 tar xzf /tmp/janeway-desk.tgz -C \$staging
 cd /urbit || exit 1
+curl -s --data '{"source":{"dojo":"+hood/unmount %$desk"},"sink":{"app":"hood"}}' http://localhost:12321
 curl -s --data '{"source":{"dojo":"+hood/mount %$desk"},"sink":{"app":"hood"}}' http://localhost:12321
 rsync -avL --delete \$staging/assembled/ $folder
 curl -s --data '{"source":{"dojo":"+hood/commit %$desk"},"sink":{"app":"hood"}}' http://localhost:12321


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this pull request does in 1-3 sentences. -->

## Changes

- Add a `+hood/unmount %$desk` poke before `+hood/mount` in the remote deploy block of `.github/helpers/deploy.sh`, so the desk is always unmounted before being (re)mounted.

## How did I test?

<!-- Describe your testing process. -->

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: CI/CD deploy script

## Rollback plan

Revert this commit; the deploy step returns to mounting without the preceding unmount.

## Screenshots / videos

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
