### PR TITLE
ui: send credentials when requesting manifest

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -20,7 +20,7 @@
       sizes="180x180"
       href="/src/assets/apple-touch-icon.png"
     />
-    <link rel="manifest" href="/src/assets/manifest.json" />
+    <link rel="manifest" href="/src/assets/manifest.json" crossorigin="use-credentials" />
     <meta
       name="theme-color"
       content="#ffffff"


### PR DESCRIPTION
Currently we use a <link rel="manifest"> element with no crossorigin field, causing the request to be sent out without cookies and unavoidably getting a 403. This needs to be specified even for requests on the same origin (https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/crossorigin#web_manifest_with_credentials)

This has never worked as far as I can tell.